### PR TITLE
Update dependencies to avoiding pinning to old Rust package versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,10 +255,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "holochain_serialized_bytes"
-version = "0.0.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.0.46"
+source = "git+https://github.com/pjkundert/holochain-serialization?branch=update-syn#544a219963b373a2838e39b560c8fa4a1b5e2368"
 dependencies = [
- "holochain_serialized_bytes_derive 0.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holochain_serialized_bytes_derive 0.0.46 (git+https://github.com/pjkundert/holochain-serialization?branch=update-syn)",
  "rmp-serde 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-transcode 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -269,28 +269,28 @@ dependencies = [
 
 [[package]]
 name = "holochain_serialized_bytes_derive"
-version = "0.0.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.0.46"
+source = "git+https://github.com/pjkundert/holochain-serialization?branch=update-syn#544a219963b373a2838e39b560c8fa4a1b5e2368"
 dependencies = [
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "holochain_wasmer_common"
-version = "0.0.49"
+version = "0.0.51"
 dependencies = [
- "holochain_serialized_bytes 0.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holochain_serialized_bytes 0.0.46 (git+https://github.com/pjkundert/holochain-serialization?branch=update-syn)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "holochain_wasmer_host"
-version = "0.0.49"
+version = "0.0.51"
 dependencies = [
- "holochain_serialized_bytes 0.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_wasmer_common 0.0.49",
+ "holochain_serialized_bytes 0.0.46 (git+https://github.com/pjkundert/holochain-serialization?branch=update-syn)",
+ "holochain_wasmer_common 0.0.51",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-runtime 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -421,26 +421,10 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -612,16 +596,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -661,11 +635,6 @@ dependencies = [
 [[package]]
 name = "typenum"
 version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -836,8 +805,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum gimli 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "81dd6190aad0f05ddbbf3245c54ed14ca4aa6dd32f22312b70d8f168c3e3e633"
 "checksum hermit-abi 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
 "checksum hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
-"checksum holochain_serialized_bytes 0.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "adca869d80860a04757af4fc011d49505594365391a6e3a04105e8f88b9c32e1"
-"checksum holochain_serialized_bytes_derive 0.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "2dbbf84d56f0a0cb00e5532fd4d40b1d42ffb403a1a964d8eeedc4d40131e208"
+"checksum holochain_serialized_bytes 0.0.46 (git+https://github.com/pjkundert/holochain-serialization?branch=update-syn)" = "<none>"
+"checksum holochain_serialized_bytes_derive 0.0.46 (git+https://github.com/pjkundert/holochain-serialization?branch=update-syn)" = "<none>"
 "checksum indexmap 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -853,9 +822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum page_size 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
 "checksum parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 "checksum parking_lot_core 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
-"checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
-"checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 "checksum raw-cpuid 7.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b4a349ca83373cfa5d6dbb66fd76e58b2cca08da71a5f6400de0a0a6a9bceeaf"
 "checksum rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098"
@@ -877,14 +844,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum smallvec 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
-"checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"
 "checksum target-lexicon 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab0e7238dcc7b40a7be719a25365910f6807bd864f4cce6b2e6b873658e2b19d"
 "checksum target-lexicon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6f4c118a7a38378f305a9e111fcb2f7f838c0be324bfb31a77ea04f7f6e684b4"
 "checksum thiserror 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
 "checksum thiserror-impl 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
 "checksum typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
-"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wasmer-clif-backend 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5ccdc1c1d6bda103fcfb8000d557e1661071e6333c42754de7459bf2456d397"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
 members = ["crates/host", "crates/common"]
 exclude = ["test"]
+
+[patch.crates-io]
+holochain_serialized_bytes = { git = "https://github.com/pjkundert/holochain-serialization", branch = "update-syn" }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -2,11 +2,11 @@
 name = "holochain_wasmer_common"
 description = "commons for both host and guest"
 license = "GPL-3.0-only"
-version = "0.0.50"
+version = "0.0.51"
 authors = [ "thedavidmeister", "thedavidmeister@gmail.com" ]
 edition = "2018"
 
 [dependencies]
-holochain_serialized_bytes = "=0.0.45"
+holochain_serialized_bytes = "=0.0.46"
 serde = "=1.0.104"
 thiserror = "1.0.10"

--- a/crates/guest/Cargo.toml
+++ b/crates/guest/Cargo.toml
@@ -2,7 +2,7 @@
 name = "holochain_wasmer_guest"
 description = "wasm guest code"
 license = "GPL-3.0-only"
-version = "0.0.50"
+version = "0.0.51"
 authors = [ "thedavidmeister", "thedavidmeister@gmail.com" ]
 edition = "2018"
 
@@ -14,6 +14,6 @@ crate-type = [ "cdylib", "rlib" ]
 path = "src/guest.rs"
 
 [dependencies]
-holochain_wasmer_common = { version = "=0.0.50", path = "../common" }
-holochain_serialized_bytes = "=0.0.45"
+holochain_wasmer_common = { version = "=0.0.51", path = "../common" }
+holochain_serialized_bytes = "=0.0.46"
 serde = "=1.0.104"

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -2,16 +2,16 @@
 name = "holochain_wasmer_host"
 description = "wasm host code"
 license = "GPL-3.0-only"
-version = "0.0.50"
+version = "0.0.51"
 authors = [ "thedavidmeister", "thedavidmeister@gmail.com" ]
 edition = "2018"
 
 [dependencies]
 wasmer-runtime-core = "=0.16.2"
 wasmer-runtime = "=0.16.2"
-holochain_wasmer_common = { version = "=0.0.50", path = "../common" }
+holochain_wasmer_common = { version = "=0.0.51", path = "../common" }
 lazy_static = "1.4.0"
-holochain_serialized_bytes = "=0.0.45"
+holochain_serialized_bytes = "=0.0.46"
 serde = "=1.0.104"
 
 [lib]


### PR DESCRIPTION
o Remove [patch.crates-io] override of holochain_serialized_bytes in
  top level Crates.toml when downstream holochain-serializion and
  observability repos are committed and upgraded in crates-io, then
  merge to master branch.

So, before merging this, merge commits to holochain/holochain-serialization and freesig/observability.

Then, address the `update-syn` branch in holochain/holochain similarly.