### PR TITLE
2022 08 15 memory issues

### DIFF
--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -14,6 +14,7 @@ serde_bytes = "0.11"
 
 [features]
 default = []
+error_as_host = []
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 wasmer = "=2.3.0"

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -16,5 +16,5 @@ serde_bytes = "0.11"
 default = []
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-wasmer = "=2.2.0"
-wasmer-engine = "=2.2.0"
+wasmer = "=2.3.0"
+wasmer-engine = "=2.3.0"

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -4,50 +4,43 @@ pub use holochain_serialized_bytes::prelude::*;
 pub use result::*;
 pub use serde_bytes;
 
-/// something like usize for wasm
-/// wasm has a memory limit of 4GB so offsets and lengths fit in u32
+/// Something like `usize` for wasm.
+/// Wasm has a memory limit of 4GB so offsets and lengths fit in `u32`.
 ///
-/// when rust compiles to the wasm32-unknown-unknown target this means that usize will be u32 in
-/// wasm but the host could interpret usize as either u32 or u64.
+/// When rust compiles to the `wasm32-unknown-unknown` target `usize` will be `u32` in
+/// wasm but the host could interpret `usize` as either `u32` or `u64`. For that reason
+/// we specify `u32` everywhere we need the host and the guest to have a shared agreement
+/// on the size of an offset/length or the host will not be able to directly
+/// manipulate the guest memory as it needs to.
 ///
-/// we need the host and the guest to have a shared agreement on the size of an offset/length or
-/// the host will not be able to directly manipulate the host memory as it needs to
-///
-/// wasmer itself uses u32 in the WasmPtr abstraction etc.
+/// wasmer itself uses `u32` in the `WasmPtr` abstraction etc.
 /// @see https://docs.rs/wasmer-runtime/0.17.0/wasmer_runtime/struct.WasmPtr.html
 pub type WasmSize = u32;
 
-/// a WasmSize integer that represents the size of bytes to read/write to memory in direct
-/// manipulations
-pub type Len = WasmSize;
-
-/// a WasmSize integer that points to a position in wasm linear memory that the host and guest are
-/// sharing to communicate across function calls
+/// A WasmSize that points to a position in wasm linear memory that the host and guest are
+/// sharing to communicate across function calls.
 pub type GuestPtr = WasmSize;
 
+/// A WasmSize integer that represents the size of bytes to read/write to memory.
+pub type Len = WasmSize;
+
+/// Enough bits to fit a pointer and length into so we can return it. The externs
+/// defined as "C" don't support multiple return values (unlike wasm). The native
+/// Rust support for wasm externs is not stable at the time of writing.
 pub type GuestPtrLen = u64;
 
-pub fn split_u64(u: GuestPtrLen) -> (GuestPtr, Len) {
-    let bytes = u.to_le_bytes();
-    (
-        GuestPtr::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
-        Len::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]),
-    )
+/// Given a pointer and a length, return a `u64` merged `GuestPtrLen`.
+/// Works via. a simple bitwise shift to move the pointer to high bits then OR
+/// the length into the low bits.
+pub fn merge_u64(guest_ptr: GuestPtr, len: Len) -> GuestPtrLen {
+    (guest_ptr as u64) << 32 | (len as u64)
 }
 
-pub fn merge_u64(guest_ptr: GuestPtr, len: Len) -> GuestPtrLen {
-    let guest_ptr_bytes = guest_ptr.to_le_bytes();
-    let len_bytes = len.to_le_bytes();
-    GuestPtrLen::from_le_bytes([
-        guest_ptr_bytes[0],
-        guest_ptr_bytes[1],
-        guest_ptr_bytes[2],
-        guest_ptr_bytes[3],
-        len_bytes[0],
-        len_bytes[1],
-        len_bytes[2],
-        len_bytes[3],
-    ])
+/// Given a merged `GuestPtrLen` split out a `u32` pointer and length.
+/// Performs the inverse of `merge_u64`. Takes the low `u32` bits as the length
+/// then shifts the 32 high bits down and takes those as the pointer.
+pub fn split_u64(u: GuestPtrLen) -> (GuestPtr, Len) {
+    ((u >> 32) as u32, u as u32)
 }
 
 #[cfg(test)]
@@ -62,7 +55,6 @@ pub mod tests {
         let (out_guest_ptr, out_len) = split_u64(merge_u64(guest_ptr, len));
 
         assert_eq!(guest_ptr, out_guest_ptr,);
-
         assert_eq!(len, out_len,);
     }
 }

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -13,15 +13,15 @@ pub use serde_bytes;
 /// on the size of an offset/length or the host will not be able to directly
 /// manipulate the guest memory as it needs to.
 ///
-/// wasmer itself uses `u32` in the `WasmPtr` abstraction etc.
+/// Wasmer itself uses `u32` in the `WasmPtr` abstraction etc.
 /// @see https://docs.rs/wasmer-runtime/0.17.0/wasmer_runtime/struct.WasmPtr.html
 pub type WasmSize = u32;
 
-/// A WasmSize that points to a position in wasm linear memory that the host and guest are
-/// sharing to communicate across function calls.
+/// A `WasmSize` that points to a position in wasm linear memory that the host
+/// and guest are sharing to communicate across function calls.
 pub type GuestPtr = WasmSize;
 
-/// A WasmSize integer that represents the size of bytes to read/write to memory.
+/// A `WasmSize` integer that represents the size of bytes to read/write to memory.
 pub type Len = WasmSize;
 
 /// Enough bits to fit a pointer and length into so we can return it. The externs

--- a/crates/common/src/result.rs
+++ b/crates/common/src/result.rs
@@ -1,7 +1,7 @@
 use holochain_serialized_bytes::prelude::*;
 use thiserror::Error;
 
-/// Enum of all possible ERROR codes that a Zome API Function could return.
+/// Enum of all possible ERROR states that wasm can can encounter.
 ///
 /// Used in [`wasm_error!`] for specifying the error type and message.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]

--- a/crates/common/src/result.rs
+++ b/crates/common/src/result.rs
@@ -174,26 +174,3 @@ impl From<&str> for WasmErrorInner {
         s.to_string().into()
     }
 }
-
-#[cfg(test)]
-pub mod tests {
-    use super::*;
-
-    #[test]
-    fn wasm_error_macro() {
-        assert_eq!(
-            wasm_error!("foo").error,
-            WasmErrorInner::Guest("foo".into()),
-        );
-
-        assert_eq!(
-            wasm_error!("{} {}", "foo", "bar").error,
-            WasmErrorInner::Guest("foo bar".into())
-        );
-
-        assert_eq!(
-            wasm_error!(WasmErrorInner::Host("foo".into())).error,
-            WasmErrorInner::Host("foo".into()),
-        );
-    }
-}

--- a/crates/common/src/result.rs
+++ b/crates/common/src/result.rs
@@ -20,7 +20,7 @@ pub enum WasmErrorInner {
     /// For example, maybe we failed to serialize an error while attempting to serialize an error.
     ErrorWhileError,
     /// Something went wrong while writing or reading bytes to/from wasm memory.
-    /// Whatever this is it is very bad and probably not recoverable.
+    /// Whatever this is, it is very bad and probably not recoverable.
     Memory,
     /// Host failed to take bytes out of the guest and do something with it.
     /// The string is whatever error message comes back from the internal process.

--- a/crates/common/src/result.rs
+++ b/crates/common/src/result.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 /// Used in [`wasm_error!`] for specifying the error type and message.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum WasmErrorInner {
-    /// While moving pointers and lengths across the host/guest we hit an unsafe
+    /// While moving pointers and lengths across the host/guest, we hit an unsafe
     /// conversion such as a negative pointer or out of bounds value.
     PointerMap,
     /// These bytes failed to deserialize.

--- a/crates/common/src/result.rs
+++ b/crates/common/src/result.rs
@@ -2,7 +2,7 @@ use holochain_serialized_bytes::prelude::*;
 use thiserror::Error;
 
 /// Enum of all possible ERROR codes that a Zome API Function could return.
-/// 
+///
 /// Used in [`wasm_error!`] for specifying the error type and message.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum WasmErrorInner {
@@ -15,7 +15,7 @@ pub enum WasmErrorInner {
     /// These bytes failed to deserialize.
     /// The host should provide nice debug info and context that the wasm guest won't have.
     #[serde(with = "serde_bytes")]
-    Deserialize(Vec<u8>),
+    Deserialize(Box<[u8]>),
     /// Something failed to serialize.
     /// This should be rare or impossible for basically everything that implements Serialize.
     Serialize(SerializedBytesError),
@@ -73,14 +73,14 @@ pub struct WasmError {
 }
 
 /// Helper macro for returning an error from a WASM.
-/// 
+///
 /// Automatically included in the error are the file and the line number where the
 /// error occurred. The error type is one of the [`WasmErrorInner`] variants.
-/// 
+///
 /// This macro is the recommended way of returning an error from a Zome function.
-/// 
+///
 /// # Example
-/// 
+///
 /// ```ignore
 /// Err(wasm_error!(WasmErrorInner::Guest("entry not found".to_string())))
 /// ```

--- a/crates/common/src/result.rs
+++ b/crates/common/src/result.rs
@@ -101,7 +101,7 @@ pub struct WasmError {
 /// This macro is the recommended way of returning an error from a Zome function.
 ///
 /// If a single expression is passed to `wasm_error!` the result will be converted
-/// to a `WasmErrorInner` via. `into()` so string and `WasmErrorInner` values are
+/// to a `WasmErrorInner` via `into()` so string and `WasmErrorInner` values are
 /// both supported directly.
 ///
 /// If a list of arguments is passed to `wasm_error!` it will first be forwarded

--- a/crates/common/src/result.rs
+++ b/crates/common/src/result.rs
@@ -54,7 +54,11 @@ impl WasmErrorInner {
             | Self::Compile(_)
             | Self::CallError(_)
             | Self::UninitializedSerializedModuleCache => true,
-            _ => false,
+            Self::Deserialize(_)
+            | Self::Serialize(_)
+            | Self::Guest(_)
+            | Self::Host(_)
+            | Self::HostShortCircuit(_) => false,
         }
     }
 }

--- a/crates/common/src/result.rs
+++ b/crates/common/src/result.rs
@@ -1,7 +1,7 @@
 use holochain_serialized_bytes::prelude::*;
 use thiserror::Error;
 
-/// Enum of all possible ERROR states that wasm can can encounter.
+/// Enum of all possible ERROR states that wasm can encounter.
 ///
 /// Used in [`wasm_error!`] for specifying the error type and message.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]

--- a/crates/guest/src/allocation.rs
+++ b/crates/guest/src/allocation.rs
@@ -31,7 +31,7 @@ pub fn consume_bytes<'a>(guest_ptr: GuestPtr, len: Len) -> Vec<u8> {
     // If `usize` is smaller than `u32`, the host cannot support that so we
     // panic/unwrap.
     let len_usize: usize = len.try_into().unwrap();
-    // This must be a Vec and not only a slice because slices will fail to
+    // This must be a Vec and not only a slice, because slices will fail to
     // deallocate memory properly when dropped.
     // Assumes length and capacity are the same which is true if `__allocate` is
     // used to allocate memory for the vector.

--- a/crates/guest/src/allocation.rs
+++ b/crates/guest/src/allocation.rs
@@ -5,7 +5,11 @@ use holochain_wasmer_common::*;
 #[no_mangle]
 #[inline(always)]
 pub extern "C" fn __allocate(len: Len) -> GuestPtr {
-    write_bytes(Vec::with_capacity(len as usize))
+    write_bytes(Vec::with_capacity(
+        // If `usize` is smaller than `u32` the host cannot support that so we
+        // panic/unwrap.
+        len.try_into().unwrap(),
+    ))
 }
 
 /// Free an allocation.
@@ -24,31 +28,30 @@ pub extern "C" fn __deallocate(guest_ptr: GuestPtr, len: Len) {
 /// the `write_bytes` function within the guest.
 #[inline(always)]
 pub fn consume_bytes<'a>(guest_ptr: GuestPtr, len: Len) -> Vec<u8> {
+    // If `usize` is smaller than `u32` the host cannot support that so we
+    // panic/unwrap.
+    let len_usize: usize = len.try_into().unwrap();
     // This must be a Vec and not only a slice because slices will fail to
     // deallocate memory properly when dropped.
     // Assumes length and capacity are the same which is true if `__allocate` is
     // used to allocate memory for the vector.
-    unsafe { std::vec::Vec::from_raw_parts(guest_ptr as *mut u8, len as usize, len as usize) }
+    unsafe { std::vec::Vec::from_raw_parts(guest_ptr as *mut u8, len_usize, len_usize) }
 }
 
-/// Attempt to write a slice of bytes.
+/// Given an owned vector of bytes, leaks it and returns a pointer the host can
+/// use to read the bytes. This does NOT handle the length of the bytes, so the
+/// guest will need to track the length separately from leaking the vector.
 ///
-/// This is identical to the following:
-/// - host has some slice of bytes
-/// - host calls `__allocate` with the slice length
-/// - guest returns `GuestPtr` to the host
-/// - host writes the bytes into the guest at `GuestPtr` location
-/// - host hands the `GuestPtr` back to the guest
-///
-/// In this case everything happens within the guest and a `GuestPtr` is returned if successful.
-///
-/// This also leaks the written bytes, exactly like the above process.
-///
-/// This facilitates the guest handing a `GuestPtr` back to the host as the _return_ value of guest
-/// functions so that the host can read the _output_ of guest logic from a pointer.
+/// This facilitates the guest handing a `GuestPtr` back to the host as the return value of guest
+/// functions so that the host can read the output of guest logic from a pointer.
 ///
 /// The host MUST ensure either `__deallocate` is called or the entire wasm memory is dropped.
+/// If the host fails to tell the guest where and how many bytes to deallocate then this leak
+/// becomes permanent to the guest.
 #[inline(always)]
 pub fn write_bytes(v: Vec<u8>) -> GuestPtr {
-    v.leak().as_ptr() as GuestPtr
+    // This *const u8 cast to u32 is safe and the only way to get a raw pointer as a u32 afaik.
+    // > e has type *T and U is a numeric type, while T: Sized; ptr-addr-cast
+    // https://web.mit.edu/rust-lang_v1.25/arch/amd64_ubuntu1404/share/doc/rust/html/book/first-edition/casting-between-types.html#pointer-casts
+    v.leak().as_ptr() as u32
 }

--- a/crates/guest/src/allocation.rs
+++ b/crates/guest/src/allocation.rs
@@ -46,7 +46,7 @@ pub fn consume_bytes<'a>(guest_ptr: GuestPtr, len: Len) -> Vec<u8> {
 /// functions so that the host can read the output of guest logic from a pointer.
 ///
 /// The host MUST ensure either `__deallocate` is called or the entire wasm memory is dropped.
-/// If the host fails to tell the guest where and how many bytes to deallocate then this leak
+/// If the host fails to tell the guest where and how many bytes to deallocate, then this leak
 /// becomes permanent to the guest.
 #[inline(always)]
 pub fn write_bytes(v: Vec<u8>) -> GuestPtr {

--- a/crates/guest/src/allocation.rs
+++ b/crates/guest/src/allocation.rs
@@ -28,7 +28,7 @@ pub extern "C" fn __deallocate(guest_ptr: GuestPtr, len: Len) {
 /// the `write_bytes` function within the guest.
 #[inline(always)]
 pub fn consume_bytes<'a>(guest_ptr: GuestPtr, len: Len) -> Vec<u8> {
-    // If `usize` is smaller than `u32` the host cannot support that so we
+    // If `usize` is smaller than `u32`, the host cannot support that so we
     // panic/unwrap.
     let len_usize: usize = len.try_into().unwrap();
     // This must be a Vec and not only a slice because slices will fail to

--- a/crates/guest/src/allocation.rs
+++ b/crates/guest/src/allocation.rs
@@ -16,17 +16,17 @@ pub extern "C" fn __deallocate(guest_ptr: GuestPtr, len: Len) {
     let _ = consume_bytes(guest_ptr, len);
 }
 
-/// Attempt to consume bytes from a known guest_ptr and len.
+/// Attempt to consume bytes from a known `guest_ptr` and `len`.
 ///
 /// Consume in this context means take ownership of previously forgotten data.
 ///
 /// This needs to work for bytes written into the guest from the host and for bytes written with
-/// the write_bytes() function within the guest.
+/// the `write_bytes` function within the guest.
 #[inline(always)]
 pub fn consume_bytes<'a>(guest_ptr: GuestPtr, len: Len) -> Vec<u8> {
     // This must be a Vec and not only a slice because slices will fail to
     // deallocate memory properly when dropped.
-    // Assumes length and capacity are the same which is true if __allocate is
+    // Assumes length and capacity are the same which is true if `__allocate` is
     // used to allocate memory for the vector.
     unsafe { std::vec::Vec::from_raw_parts(guest_ptr as *mut u8, len as usize, len as usize) }
 }
@@ -35,19 +35,19 @@ pub fn consume_bytes<'a>(guest_ptr: GuestPtr, len: Len) -> Vec<u8> {
 ///
 /// This is identical to the following:
 /// - host has some slice of bytes
-/// - host calls __allocate with the slice length
-/// - guest returns GuestPtr to the host
-/// - host writes the bytes into the guest at GuestPtr location
-/// - host hands the GuestPtr back to the guest
+/// - host calls `__allocate` with the slice length
+/// - guest returns `GuestPtr` to the host
+/// - host writes the bytes into the guest at `GuestPtr` location
+/// - host hands the `GuestPtr` back to the guest
 ///
-/// In this case everything happens within the guest and a GuestPtr is returned if successful.
+/// In this case everything happens within the guest and a `GuestPtr` is returned if successful.
 ///
 /// This also leaks the written bytes, exactly like the above process.
 ///
-/// This facilitates the guest handing a GuestPtr back to the host as the _return_ value of guest
+/// This facilitates the guest handing a `GuestPtr` back to the host as the _return_ value of guest
 /// functions so that the host can read the _output_ of guest logic from a pointer.
 ///
-/// The host MUST ensure either __deallocate is called or the entire wasm memory is dropped.
+/// The host MUST ensure either `__deallocate` is called or the entire wasm memory is dropped.
 #[inline(always)]
 pub fn write_bytes(v: Vec<u8>) -> GuestPtr {
     v.leak().as_ptr() as GuestPtr

--- a/crates/guest/src/allocation.rs
+++ b/crates/guest/src/allocation.rs
@@ -33,7 +33,7 @@ pub fn consume_bytes<'a>(guest_ptr: GuestPtr, len: Len) -> Vec<u8> {
     let len_usize: usize = len.try_into().unwrap();
     // This must be a Vec and not only a slice, because slices will fail to
     // deallocate memory properly when dropped.
-    // Assumes length and capacity are the same which is true if `__allocate` is
+    // Assumes length and capacity are the same, which is true if `__allocate` is
     // used to allocate memory for the vector.
     unsafe { std::vec::Vec::from_raw_parts(guest_ptr as *mut u8, len_usize, len_usize) }
 }

--- a/crates/guest/src/guest.rs
+++ b/crates/guest/src/guest.rs
@@ -134,7 +134,7 @@ pub fn return_err_ptr(wasm_error: WasmError) -> GuestPtrLen {
                     };
                     merge_u64(write_bytes(bytes), len)
                 }
-                // At this point we failed to serialize a unit varaint so IDK ¯\_(ツ)_/¯
+                // At this point we failed to serialize a unit variant so IDK ¯\_(ツ)_/¯
                 Err(_) => panic!("Failed to error"),
             },
         },

--- a/crates/guest/src/guest.rs
+++ b/crates/guest/src/guest.rs
@@ -32,7 +32,7 @@ where
         Err(e) => {
             tracing::error!(input_type = std::any::type_name::<O>(), bytes = ?bytes, "{}", e);
             Err(return_err_ptr(wasm_error!(WasmErrorInner::Deserialize(
-                bytes
+                bytes.into()
             ))))
         }
     }
@@ -67,12 +67,12 @@ where
     });
 
     // Deserialize the host bytes into the output type.
-    let bytes: Vec<u8> = crate::allocation::consume_bytes(output_guest_ptr, output_len);
-    match holochain_serialized_bytes::decode::<Vec<u8>, Result<O, WasmError>>(&bytes) {
+    let bytes = crate::allocation::consume_bytes(output_guest_ptr, output_len);
+    match holochain_serialized_bytes::decode::<[u8], Result<O, WasmError>>(&bytes) {
         Ok(output) => Ok(output?),
         Err(e) => {
             tracing::error!(output_type = std::any::type_name::<O>(), ?bytes, "{}", e);
-            Err(wasm_error!(WasmErrorInner::Deserialize(bytes)))
+            Err(wasm_error!(WasmErrorInner::Deserialize(bytes.into())))
         }
     }
 }

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -7,7 +7,7 @@ authors = [ "thedavidmeister", "thedavidmeister@gmail.com" ]
 edition = "2021"
 
 [dependencies]
-wasmer = "=2.2.0"
+wasmer = "=2.3.0"
 holochain_wasmer_common = { version = "=0.0.80", path = "../common" }
 holochain_serialized_bytes = "=0.0.51"
 serde = "1.0.136"
@@ -18,14 +18,14 @@ rand = "0.8.3"
 bimap = "=0.6.1"
 
 # TODO: remove these when updating to a version of wasmer that fixes these
-wasmer-compiler = "=2.2.0"
-wasmer-compiler-cranelift = "=2.2.0"
-wasmer-derive = "=2.2.0"
-wasmer-engine = "=2.2.0"
-wasmer-engine-dylib = "=2.2.0"
-wasmer-engine-universal = "=2.2.0"
-wasmer-types = "=2.2.0"
-wasmer-vm = "=2.2.0"
+wasmer-compiler = "=2.3.0"
+wasmer-compiler-cranelift = "=2.3.0"
+wasmer-derive = "=2.3.0"
+wasmer-engine = "=2.3.0"
+wasmer-engine-dylib = "=2.3.0"
+wasmer-engine-universal = "=2.3.0"
+wasmer-types = "=2.3.0"
+wasmer-vm = "=2.3.0"
 
 [lib]
 name = "holochain_wasmer_host"

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -33,5 +33,6 @@ crate-type = [ "cdylib", "rlib" ]
 path = "src/host.rs"
 
 [features]
-default = []
+default = ["error_as_host"]
 debug_memory = []
+error_as_host = ["holochain_wasmer_common/error_as_host"]

--- a/crates/host/src/env.rs
+++ b/crates/host/src/env.rs
@@ -16,6 +16,9 @@ pub struct Env {
 }
 
 impl Env {
+    /// Given some input I that can be serialized, request an allocation from the
+    /// guest and copy the serialized bytes to the allocated pointer. The guest
+    /// MUST subsequently take ownership of these bytes or it will leak memory.
     pub fn move_data_to_guest<I>(
         &self,
         input: I,
@@ -32,7 +35,7 @@ impl Env {
                     .try_into()
                     .map_err(|_| wasm_error!(WasmErrorInner::PointerMap))?,
             )])
-            .map_err(|e| wasm_error!(WasmErrorInner::Host(e.to_string())))?[0]
+            .map_err(|e| wasm_error!(e.to_string()))?[0]
         {
             Value::I32(guest_ptr) => guest_ptr as GuestPtr,
             _ => return Err(wasm_error!(WasmErrorInner::PointerMap).into()),
@@ -47,6 +50,10 @@ impl Env {
         Ok(merge_u64(guest_ptr, len))
     }
 
+    /// Given a pointer and length for a region of memory in the guest, copy the
+    /// bytes to the host and attempt to deserialize type `O` from the data. The
+    /// guest will be asked to deallocate the copied bytes whether or not the
+    /// deserialization is successful.
     pub fn consume_bytes_from_guest<O>(
         &self,
         guest_ptr: GuestPtr,
@@ -74,7 +81,7 @@ impl Env {
                         .map_err(|_| wasm_error!(WasmErrorInner::PointerMap))?,
                 ),
             ])
-            .map_err(|e| wasm_error!(WasmErrorInner::Host(e.to_string())))?;
+            .map_err(|e| wasm_error!(e.to_string()))?;
         match holochain_serialized_bytes::decode(&bytes) {
             Ok(v) => Ok(v),
             Err(e) => {

--- a/crates/host/src/env.rs
+++ b/crates/host/src/env.rs
@@ -23,7 +23,7 @@ impl Env {
     where
         I: serde::Serialize + std::fmt::Debug,
     {
-        let data = holochain_serialized_bytes::encode(&input).map_err(|e| wasm_error!(e.into()))?;
+        let data = holochain_serialized_bytes::encode(&input).map_err(|e| wasm_error!(e))?;
         let guest_ptr: GuestPtr = match self
             .allocate_ref()
             .ok_or(wasm_error!(WasmErrorInner::Memory))?
@@ -79,7 +79,7 @@ impl Env {
             Ok(v) => Ok(v),
             Err(e) => {
                 tracing::error!(input_type = std::any::type_name::<O>(), bytes = ?bytes, "{}", e);
-                Err(wasm_error!(e.into()).into())
+                Err(wasm_error!(e).into())
             }
         }
     }

--- a/crates/host/src/guest.rs
+++ b/crates/host/src/guest.rs
@@ -40,7 +40,7 @@ use wasmer::Value;
 /// This is still not completely safe in the face of shared memory and threads, etc.
 ///
 /// The guest needs to provide a pointer to a pre-allocated (e.g. by leaking a Vec<u8>) region
-/// of the guest's memory that it is safe for the host to write to.
+/// of the guest's memory that is safe for the host to write to.
 ///
 /// It is the host's responsibility to tell the guest the length of the allocation that is needed
 /// and the guest's responsibility to correctly reserve an allocation to be written into.

--- a/crates/host/src/guest.rs
+++ b/crates/host/src/guest.rs
@@ -23,7 +23,7 @@ use wasmer::Value;
 /// ```
 ///
 /// The guest memory is part of the host memory, so we get the host's pointer to the start of the
-/// guest's memory with `view.as_ptr()` then we add the guest's pointer to where it wants to see the
+/// guest's memory with `view.as_ptr()`, then we add the guest's pointer to where it wants to see the
 /// written bytes then copy the slice directly across.
 ///
 /// The problem with this approach is that the `guest_ptr` typically needs to be provided by the

--- a/crates/host/src/guest.rs
+++ b/crates/host/src/guest.rs
@@ -29,7 +29,7 @@ use wasmer::Value;
 /// The problem with this approach is that the `guest_ptr` typically needs to be provided by the
 /// allocator in the guest wasm in order to be safe for the guest's consumption, but a malicious
 /// guest could provide bogus `guest_ptr` values that point outside the bounds of the guest memory.
-/// the naive host would then corrupt its own memory by copying bytes... wherever, basically.
+/// The naive host would then corrupt its own memory by copying bytes... wherever, basically.
 ///
 /// A better approach is to use wasmer's `WasmPtr` abstraction, which checks against the memory
 /// bounds of the guest based on the input type and can be dereferenced to a [Cell] slice that we

--- a/crates/host/src/guest.rs
+++ b/crates/host/src/guest.rs
@@ -24,7 +24,7 @@ use wasmer::Value;
 ///
 /// The guest memory is part of the host memory, so we get the host's pointer to the start of the
 /// guest's memory with `view.as_ptr()`, then we add the guest's pointer to where it wants to see the
-/// written bytes then copy the slice directly across.
+/// written bytes, then copy the slice directly across.
 ///
 /// The problem with this approach is that the `guest_ptr` typically needs to be provided by the
 /// allocator in the guest wasm in order to be safe for the guest's consumption, but a malicious

--- a/crates/host/src/guest.rs
+++ b/crates/host/src/guest.rs
@@ -164,7 +164,7 @@ where
         Ok(v) => Ok(v),
         Err(e) => {
             tracing::error!(input_type = std::any::type_name::<O>(), bytes = ?bytes, "{}", e);
-            Err(wasm_error!(e.into()).into())
+            Err(wasm_error!(e).into())
         }
     }
 }
@@ -184,7 +184,7 @@ where
     let instance = instance.lock();
     // The guest will use the same crate for decoding if it uses the wasm common crate.
     let payload: Vec<u8> =
-        holochain_serialized_bytes::encode(&input).map_err(|e| wasm_error!(e.into()))?;
+        holochain_serialized_bytes::encode(&input).map_err(|e| wasm_error!(e))?;
 
     // Get a pre-allocated guest pointer to write the input into.
     let guest_input_length = payload
@@ -250,7 +250,7 @@ where
                                 "{}",
                                 e
                             );
-                            Err(wasm_error!(e.into()).into())
+                            Err(wasm_error!(e).into())
                         }
                     }
                 }
@@ -284,11 +284,11 @@ where
             Value::I32(
                 guest_return_ptr
                     .try_into()
-                    .map_err(|e: TryFromIntError| wasm_error!(e.into()))?,
+                    .map_err(|e: TryFromIntError| wasm_error!(e))?,
             ),
             Value::I32(
                 len.try_into()
-                    .map_err(|e: TryFromIntError| wasm_error!(e.into()))?,
+                    .map_err(|e: TryFromIntError| wasm_error!(e))?,
             ),
         ])
         .map_err(|e| wasm_error!(WasmErrorInner::CallError(format!("{:?}", e))))?;

--- a/crates/host/src/module.rs
+++ b/crates/host/src/module.rs
@@ -11,22 +11,38 @@ use wasmer::Module;
 use wasmer::Store;
 use wasmer::Universal;
 
+/// We expect cache keys to be produced via hashing so 32 bytes is enough for all
+/// purposes.
 pub type CacheKey = [u8; 32];
+/// Plru uses a usize to track "recently used" so we need a map between 32 byte cache
+/// keys and the bits used to evict things from the cache.
 pub type PlruKeyMap = BiMap<usize, CacheKey>;
+/// Modules serialize to a vec of bytes as per wasmer.
 pub type SerializedModule = Vec<u8>;
 
+/// Higher level trait over the plru cache to make it a bit easier to interact
+/// with consistently. Default implementations for key functions are provided.
+/// Notably handles keeping the mapping between cache keys and items, and the
+/// plru tracking including touching and evicting.
 pub trait PlruCache {
+    /// The type of items in the cache.
     type Item;
-
+    /// Accessor for mutable reference to internal plru cache.
     fn plru_mut(&mut self) -> &mut MicroCache;
+    /// Accessor to mapping between plru cache bits and cache keys.
     fn key_map(&self) -> &PlruKeyMap;
+    /// Mutable accessor to mapping between plru cache bits and cache keys.
     fn key_map_mut(&mut self) -> &mut PlruKeyMap;
+    /// Accessor to the cache key addressable cache of items.
     fn cache(&self) -> &BTreeMap<CacheKey, Arc<Self::Item>>;
+    /// Mutable accessor to the cache key addressable cache of items.
     fn cache_mut(&mut self) -> &mut BTreeMap<CacheKey, Arc<Self::Item>>;
-
+    /// Put an item in both the plru cache and the item cache by its cache key.
+    /// If the cache is full, the roughly most stale plru will be evicted from the
+    /// item cache and reassigned to the new item.
     fn put_item(&mut self, key: CacheKey, item: Arc<Self::Item>) -> Arc<Self::Item> {
         let plru_key = self.plru_mut().replace();
-        // if there is something in the cache for this plru slot already drop it.
+        // If there is something in the cache for this plru slot already drop it.
         if let Some(stale_key) = self.key_map().get_by_left(&plru_key).cloned() {
             self.cache_mut().remove(&stale_key);
         }
@@ -35,7 +51,9 @@ pub trait PlruCache {
         self.key_map_mut().insert(plru_key, key);
         item
     }
-
+    /// Get the plru key for a given cache key. Will panic if the mapping does not
+    /// exist so the caller MUST NOT request the plru on a cache miss AND that the
+    /// cache is never set such as to cause a hit without also setting the plru.
     fn plru_key(&self, key: &CacheKey) -> usize {
         *self
             .key_map()
@@ -45,16 +63,21 @@ pub trait PlruCache {
             .expect("Missing cache plru key mapping. This is a bug.")
     }
 
+    /// Touches the plru such that the given CacheKey becomes the most recently
+    /// used item.
     fn touch(&mut self, key: &CacheKey) {
         let plru_key = self.plru_key(key);
         self.plru_mut().touch(plru_key);
     }
 
+    /// Delete the plru for a given cache key. Care must be taken to ensure this
+    /// is not called before a subsequent call to `plru_key` or it will panic.
     fn trash(&mut self, key: &CacheKey) {
         let plru_key = self.plru_key(key);
         self.plru_mut().trash(plru_key);
     }
 
+    /// Remove an item from the cache and the associated plru entry.
     fn remove_item(&mut self, key: &CacheKey) -> Option<Arc<Self::Item>> {
         let maybe_item = self.cache_mut().remove(key);
         if maybe_item.is_some() {
@@ -65,6 +88,7 @@ pub trait PlruCache {
         maybe_item
     }
 
+    /// Attempt to retrieve an item from the cache by its cache key.
     fn get_item(&mut self, key: &CacheKey) -> Option<Arc<Self::Item>> {
         let maybe_item = self.cache().get(key).cloned();
         if maybe_item.is_some() {
@@ -74,6 +98,10 @@ pub trait PlruCache {
     }
 }
 
+/// Cache for serialized modules. These are fully compiled wasm modules that are
+/// then serialized by wasmer and can be cached. A serialized wasm module must still
+/// be deserialized before it can be used to build instances. The deserialization
+/// process is far faster than compiling and much slower than instance building.
 pub struct SerializedModuleCache {
     plru: MicroCache,
     key_map: PlruKeyMap,
@@ -108,6 +136,8 @@ impl PlruCache for SerializedModuleCache {
 }
 
 impl SerializedModuleCache {
+    /// Build a default `SerializedModuleCache` with a `Cranelift` that will be used
+    /// to compile modules for serialization as needed.
     pub fn default_with_cranelift(cranelift: fn() -> Cranelift) -> Self {
         Self {
             cranelift,
@@ -116,6 +146,9 @@ impl SerializedModuleCache {
             cache: BTreeMap::default(),
         }
     }
+
+    /// Given a wasm, compiles with cranelift, serializes the result, adds it to
+    /// the cache and returns that.
     fn get_with_build_cache(
         &mut self,
         key: CacheKey,
@@ -131,6 +164,8 @@ impl SerializedModuleCache {
         Ok(module)
     }
 
+    /// Given a wasm, attempts to get the serialized module for it from the cache.
+    /// If the cache misses a new serialized module, will be built from the wasm.
     pub fn get(
         &mut self,
         key: CacheKey,
@@ -149,6 +184,8 @@ impl SerializedModuleCache {
     }
 }
 
+/// Caches wasmer modules that can be used to build wasmer instances. This is the
+/// output of building from wasm or deserializing the items in the serialized module cache.
 #[derive(Default)]
 pub struct ModuleCache {
     plru: MicroCache,
@@ -160,6 +197,8 @@ pub static MODULE_CACHE: Lazy<RwLock<ModuleCache>> =
     Lazy::new(|| RwLock::new(ModuleCache::default()));
 
 impl ModuleCache {
+    /// Wraps the serialized module cache to build modules as needed and also cache
+    /// the module itself in the module cache.
     fn get_with_build_cache(
         &mut self,
         key: CacheKey,
@@ -176,6 +215,9 @@ impl ModuleCache {
         Ok(self.put_item(key, Arc::new(module)))
     }
 
+    /// Attempts to retrieve a module ready to build instances from. Builds a new
+    /// module from the provided wasm and caches both the module and a serialized
+    /// copy of the module if there is a miss.
     pub fn get(
         &mut self,
         key: CacheKey,
@@ -212,6 +254,10 @@ impl PlruCache for ModuleCache {
     }
 }
 
+/// Caches wasm instances. Reusing wasm instances allows maximum speed in function
+/// calls but also introduces the possibility of memory corruption or other bad
+/// state that is inappropriate to persist/reuse/access across calls. It is the
+/// responsibility of the host to discard instances that are not eligible for reuse.
 #[derive(Default)]
 pub struct InstanceCache {
     plru: MicroCache,

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,8 @@ cargo fmt
 # tests the root workspace that doesn't include any wasm code
 cargo test -- --nocapture
 
-# cargo build --release --manifest-path test/test_wasm/Cargo.toml --target wasm32-unknown-unknown -Z unstable-options
+# test that everything builds
+cargo build --release --manifest-path test/test_wasm/Cargo.toml --target wasm32-unknown-unknown
 
 # build wasm and run the "full" tests
 cargo test --release --manifest-path test/Cargo.toml ${1} -- --nocapture

--- a/test.sh
+++ b/test.sh
@@ -10,4 +10,4 @@ cargo test -- --nocapture
 # cargo build --release --manifest-path test/test_wasm/Cargo.toml --target wasm32-unknown-unknown -Z unstable-options
 
 # build wasm and run the "full" tests
-cargo test --manifest-path test/Cargo.toml ${1} -- --nocapture
+cargo test --release --manifest-path test/Cargo.toml ${1} -- --nocapture

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -50,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
@@ -164,25 +164,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-bforest"
-version = "0.76.0"
+name = "corosensei"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6bea67967505247f54fa2c85cf4f6e0e31c4e5692c9b70e4ae58e339067333"
+checksum = "9847f90f32a50b0dcbd68bc23ff242798b13080b97b0569f6ed96a45ce4cf2cd"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "libc",
+ "scopeguard",
+ "windows-sys",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.82.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38faa2a16616c8e78a18d37b4726b98bfd2de192f2fdc8a39ddf568a408a0f75"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48194035d2752bdd5bdae429e3ab88676e95f52a2b1355a5d4e809f9e39b1d74"
+checksum = "26f192472a3ba23860afd07d2b0217dc628f21fcc72617aa1336d98e1671f33b"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
  "cranelift-entity",
- "gimli 0.25.0",
+ "gimli 0.26.2",
  "log",
  "regalloc",
  "smallvec",
@@ -191,31 +204,30 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976efb22fcab4f2cd6bd4e9913764616a54d895c1a23530128d04e03633c555f"
+checksum = "0f32ddb89e9b89d3d9b36a5b7d7ea3261c98235a76ac95ba46826b8ec40b1a24"
 dependencies = [
  "cranelift-codegen-shared",
- "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dabb5fe66e04d4652e434195b45ae65b5c8172d520247b8f66d8df42b2b45dc"
+checksum = "01fd0d9f288cc1b42d9333b7a776b17e278fc888c28e6a0f09b5573d45a150bc"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3329733e4d4b8e91c809efcaa4faee80bf66f20164e3dd16d707346bd3494799"
+checksum = "9e3bfe172b83167604601faf9dc60453e0d0a93415b57a9c4d1a7ae6849185cf"
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279afcc0d3e651b773f94837c3d581177b348c8d69e928104b2e9fccb226f921"
+checksum = "a006e3e32d80ce0e4ba7f1f9ddf66066d052a8c884a110b91d05404d6ce26dce"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -481,9 +493,9 @@ checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "gimli"
-version = "0.25.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 dependencies = [
  "fallible-iterator",
  "indexmap",
@@ -653,9 +665,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
 
 [[package]]
 name = "libloading"
@@ -1032,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc"
-version = "0.0.31"
+version = "0.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
+checksum = "62446b1d3ebf980bdc68837700af1d77b37bc430e524bf95319c6eada2a4cc02"
 dependencies = [
  "log",
  "rustc-hash",
@@ -1528,9 +1540,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc7dff846db3f38f8ed0be4a009fdfeb729cf1f94a2c7fb6ff2fec01cefa110"
+checksum = "ea8d8361c9d006ea3d7797de7bd6b1492ffd0f91a22430cfda6c1658ad57bedf"
 dependencies = [
  "cfg-if 1.0.0",
  "indexmap",
@@ -1540,6 +1552,7 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasm-bindgen",
+ "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-compiler-cranelift",
  "wasmer-derive",
@@ -1553,10 +1566,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmer-compiler"
-version = "2.2.0"
+name = "wasmer-artifact"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c91abf22b16dad3826ec0d0e3ec0a8304262a6c7a14e16528c536131b80e63d"
+checksum = "7aaf9428c29c1d8ad2ac0e45889ba8a568a835e33fd058964e5e500f2f7ce325"
+dependencies = [
+ "enumset",
+ "loupe",
+ "thiserror",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-compiler"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67a6cd866aed456656db2cfea96c18baabbd33f676578482b85c51e1ee19d2c"
 dependencies = [
  "enumset",
  "loupe",
@@ -1567,20 +1593,19 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasmer-types",
- "wasmer-vm",
  "wasmparser",
 ]
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7624a1f496b163139a7e0b442426cad805bec70486900287506f9d15a29323ab"
+checksum = "48be2f9f6495f08649e4f8b946a2cbbe119faf5a654aa1457f9504a99d23dae0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
- "gimli 0.25.0",
+ "gimli 0.26.2",
  "loupe",
  "more-asserts",
  "rayon",
@@ -1589,14 +1614,13 @@ dependencies = [
  "tracing",
  "wasmer-compiler",
  "wasmer-types",
- "wasmer-vm",
 ]
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "933b23b5cee0f58aa6c17c6de7e1f3007279357e0d555f22e24d6b395cfe7f89"
+checksum = "00e50405cc2a2f74ff574584710a5f2c1d5c93744acce2ca0866084739284b51"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1606,9 +1630,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41db0ac4df90610cda8320cfd5abf90c6ec90e298b6fe5a09a81dff718b55640"
+checksum = "3f98f010978c244db431b392aeab0661df7ea0822343334f8f2a920763548e45"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1621,6 +1645,7 @@ dependencies = [
  "serde_bytes",
  "target-lexicon",
  "thiserror",
+ "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-types",
  "wasmer-vm",
@@ -1628,9 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591683f3356ac31cc88aaecaf77ac2cc9f456014348b01af46c164f44f531162"
+checksum = "ad0358af9c154724587731175553805648d9acb8f6657880d165e378672b7e53"
 dependencies = [
  "cfg-if 1.0.0",
  "enum-iterator",
@@ -1643,6 +1668,7 @@ dependencies = [
  "serde",
  "tempfile",
  "tracing",
+ "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-engine",
  "wasmer-object",
@@ -1653,12 +1679,11 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dccfde103e9b87427099a6de344b7c791574f307d035c8c7dbbc00974c1af0c1"
+checksum = "440dc3d93c9ca47865a4f4edd037ea81bf983b5796b59b3d712d844b32dbef15"
 dependencies = [
  "cfg-if 1.0.0",
- "enum-iterator",
  "enumset",
  "leb128",
  "loupe",
@@ -1666,16 +1691,33 @@ dependencies = [
  "rkyv",
  "wasmer-compiler",
  "wasmer-engine",
+ "wasmer-engine-universal-artifact",
  "wasmer-types",
  "wasmer-vm",
  "winapi",
 ]
 
 [[package]]
-name = "wasmer-middlewares"
-version = "2.2.0"
+name = "wasmer-engine-universal-artifact"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be816528dd62f037ae935977b643bb4237e10be9e32826e2f3eb1f911eaccc97"
+checksum = "68f1db3f54152657eb6e86c44b66525ff7801dad8328fe677da48dd06af9ad41"
+dependencies = [
+ "enum-iterator",
+ "enumset",
+ "loupe",
+ "rkyv",
+ "thiserror",
+ "wasmer-artifact",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-middlewares"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7812438ed2f37203a37007cdb5332b8475cb2b16e15d51299b2647894e9ed3a"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1685,9 +1727,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0c4005592998bd840f2289102ef9c67b6138338ed78e1fc0809586aa229040"
+checksum = "8d831335ff3a44ecf451303f6f891175c642488036b92ceceb24ac8623a8fa8b"
 dependencies = [
  "object 0.28.3",
  "thiserror",
@@ -1697,12 +1739,15 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4deb854f178265a76b59823c41547d259c65da3687b606b0b9c12d80ab950e3e"
+checksum = "39df01ea05dc0a9bab67e054c7cb01521e53b35a7bb90bd02eca564ed0b2667f"
 dependencies = [
+ "backtrace",
+ "enum-iterator",
  "indexmap",
  "loupe",
+ "more-asserts",
  "rkyv",
  "serde",
  "thiserror",
@@ -1710,32 +1755,37 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dbc5c989cb14a102433927e630473da52f83d82c469acd5cfa8fc7efacc1e70"
+checksum = "30d965fa61f4dc4cdb35a54daaf7ecec3563fbb94154a6c35433f879466247dd"
 dependencies = [
  "backtrace",
  "cc",
  "cfg-if 1.0.0",
+ "corosensei",
  "enum-iterator",
  "indexmap",
+ "lazy_static",
  "libc",
  "loupe",
+ "mach",
  "memoffset",
  "more-asserts",
  "region",
  "rkyv",
+ "scopeguard",
  "serde",
  "thiserror",
+ "wasmer-artifact",
  "wasmer-types",
  "winapi",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.78.0"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c7a8b20306d43c09c2c34e0ef68bf2959a11b01a5cae35e4c5dc1e7145547b6"
+checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
 name = "wast"
@@ -1805,3 +1855,46 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43dbb096663629518eb1dfa72d80243ca5a6aca764cae62a2df70af760a9be75"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -14,9 +14,9 @@ criterion = "0.3"
 rand = "0.7"
 serde_bytes = "0.11"
 parking_lot = "0.11.1"
-wasmer = "=2.2.0"
-wasmer-engine = "=2.2.0"
-wasmer-middlewares = "=2.2.0"
+wasmer = "=2.3.0"
+wasmer-engine = "=2.3.0"
+wasmer-middlewares = "=2.3.0"
 
 [dev-dependencies]
 env_logger = "0.8"

--- a/test/benches/bench.rs
+++ b/test/benches/bench.rs
@@ -18,7 +18,7 @@ pub fn wasm_module(c: &mut Criterion) {
     ] {
         group.bench_function(BenchmarkId::new("wasm_module", wasm.name()), |b| {
             b.iter(|| {
-                wasm.module();
+                wasm.module(false);
             })
         });
     }
@@ -38,7 +38,7 @@ pub fn wasm_instance(c: &mut Criterion) {
     ] {
         group.bench_function(BenchmarkId::new("wasm_instance", wasm.name()), |b| {
             b.iter(|| {
-                let module = wasm.module();
+                let module = wasm.module(false);
                 let env = Env::default();
                 let import_object: wasmer::ImportObject = imports! {
                     "env" => {
@@ -81,7 +81,7 @@ pub fn wasm_instance(c: &mut Criterion) {
 pub fn wasm_call(c: &mut Criterion) {
     let mut group = c.benchmark_group("wasm_call");
 
-    let instance = TestWasm::Io.instance();
+    let instance = TestWasm::Io.unmetered_instance();
 
     macro_rules! bench_call {
         ( $fs:expr; $t:tt; $n:ident; $build:expr; ) => {
@@ -116,7 +116,7 @@ pub fn wasm_call(c: &mut Criterion) {
 
     bench_call!(
         vec![
-            // "string_input_ignored_empty_ret",
+            "string_input_ignored_empty_ret",
             "string_input_args_empty_ret",
             "string_input_args_echo_ret",
         ];

--- a/test/benches/bench.rs
+++ b/test/benches/bench.rs
@@ -116,13 +116,13 @@ pub fn wasm_call(c: &mut Criterion) {
 
     bench_call!(
         vec![
-            "string_input_ignored_empty_ret",
+            // "string_input_ignored_empty_ret",
             "string_input_args_empty_ret",
             "string_input_args_echo_ret",
         ];
         StringType;
         n;
-        ".".repeat(n);
+        ".".repeat(n.try_into().unwrap());
     );
 
     bench_call!(
@@ -133,7 +133,7 @@ pub fn wasm_call(c: &mut Criterion) {
         ];
         BytesType;
         n;
-        vec![0; n];
+        vec![0; n.try_into().unwrap()];
     );
 
     group.finish();
@@ -152,8 +152,8 @@ pub fn wasm_call_n(c: &mut Criterion) {
             fs.shuffle(&mut thread_rng());
 
             for f in fs {
-                for n in vec![0, 1, 1_000, 1_000_000] {
-                    group.throughput(Throughput::Bytes(n));
+                for n in vec![0_u32, 1, 1_000, 1_000_000] {
+                    group.throughput(Throughput::Bytes(n.try_into().unwrap()));
                     group.sample_size(10);
 
                     group.bench_with_input(
@@ -190,7 +190,7 @@ pub fn test_process_string(c: &mut Criterion) {
     for n in vec![0, 1, 1_000, 1_000_000] {
         group.throughput(Throughput::Bytes(n));
         group.sample_size(10);
-        let input = test_common::StringType::from(".".repeat(n));
+        let input = test_common::StringType::from(".".repeat(n.try_into().unwrap()));
         group.bench_with_input(BenchmarkId::new("test_process_string", n), &n, |b, _| {
             b.iter(|| {
                 let _: test_common::StringType = holochain_wasmer_host::guest::call(

--- a/test/benches/bench.rs
+++ b/test/benches/bench.rs
@@ -91,7 +91,7 @@ pub fn wasm_call(c: &mut Criterion) {
 
             for f in fs {
                 for $n in vec![0, 1, 1_000, 1_000_000] {
-                    group.throughput(Throughput::Bytes($n as _));
+                    group.throughput(Throughput::Bytes($n));
                     group.sample_size(10);
 
                     let input = test_common::$t::from($build);
@@ -153,7 +153,7 @@ pub fn wasm_call_n(c: &mut Criterion) {
 
             for f in fs {
                 for n in vec![0, 1, 1_000, 1_000_000] {
-                    group.throughput(Throughput::Bytes(n as _));
+                    group.throughput(Throughput::Bytes(n));
                     group.sample_size(10);
 
                     group.bench_with_input(
@@ -188,7 +188,7 @@ pub fn test_process_string(c: &mut Criterion) {
     let instance = TestWasm::Test.instance();
 
     for n in vec![0, 1, 1_000, 1_000_000] {
-        group.throughput(Throughput::Bytes(n as _));
+        group.throughput(Throughput::Bytes(n));
         group.sample_size(10);
         let input = test_common::StringType::from(".".repeat(n));
         group.bench_with_input(BenchmarkId::new("test_process_string", n), &n, |b, _| {
@@ -208,7 +208,7 @@ pub fn test_process_string(c: &mut Criterion) {
 
 pub fn test_instances(c: &mut Criterion) {
     let mut group = c.benchmark_group("test_instances");
-    group.throughput(Throughput::Bytes(1_000 as _));
+    group.throughput(Throughput::Bytes(1_000));
     group.sample_size(100);
     let input = test_common::StringType::from(".".repeat(1000));
     group.bench_with_input(BenchmarkId::new("test_instances", 1000), &1000, |b, _| {

--- a/test/src/test.rs
+++ b/test/src/test.rs
@@ -6,8 +6,7 @@ use test_common::SomeStruct;
 
 pub fn short_circuit(_: &Env, _: GuestPtr, _: Len) -> Result<u64, wasmer_engine::RuntimeError> {
     Err(wasm_error!(WasmErrorInner::HostShortCircuit(
-        holochain_serialized_bytes::encode(&String::from("shorts"))
-            .map_err(|e| wasm_error!(e.into()))?,
+        holochain_serialized_bytes::encode(&String::from("shorts")).map_err(|e| wasm_error!(e))?,
     ))
     .into())
 }

--- a/test/src/test.rs
+++ b/test/src/test.rs
@@ -112,7 +112,8 @@ pub mod tests {
     fn process_string_test() {
         // use a "crazy" string that is much longer than a single wasm page to show that pagination
         // and utf-8 are both working OK
-        let starter_string = "╰▐ ✖ 〜 ✖ ▐╯".repeat((10_u32 * std::u16::MAX as u32) as _);
+        let starter_string = "╰▐ ✖ 〜 ✖ ▐╯"
+            .repeat(usize::try_from(10_u32 * u32::try_from(std::u16::MAX).unwrap()).unwrap());
         let result: StringType = guest::call(
             TestWasm::Test.instance(),
             "process_string",

--- a/test/src/test.rs
+++ b/test/src/test.rs
@@ -73,7 +73,12 @@ pub mod tests {
 
     #[test]
     fn bytes_round_trip() {
-        let _: () = guest::call(TestWasm::Memory.instance(), "bytes_round_trip", ()).unwrap();
+        let _: () = dbg!(guest::call(
+            TestWasm::Memory.instance(),
+            "bytes_round_trip",
+            ()
+        ))
+        .unwrap();
     }
 
     #[test]

--- a/test/test_wasm/Cargo.lock
+++ b/test/test_wasm/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
- "gimli 0.26.1",
+ "gimli",
 ]
 
 [[package]]
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
@@ -101,25 +101,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cranelift-bforest"
-version = "0.76.0"
+name = "corosensei"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6bea67967505247f54fa2c85cf4f6e0e31c4e5692c9b70e4ae58e339067333"
+checksum = "9847f90f32a50b0dcbd68bc23ff242798b13080b97b0569f6ed96a45ce4cf2cd"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "libc",
+ "scopeguard",
+ "windows-sys",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.82.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38faa2a16616c8e78a18d37b4726b98bfd2de192f2fdc8a39ddf568a408a0f75"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48194035d2752bdd5bdae429e3ab88676e95f52a2b1355a5d4e809f9e39b1d74"
+checksum = "26f192472a3ba23860afd07d2b0217dc628f21fcc72617aa1336d98e1671f33b"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
  "cranelift-entity",
- "gimli 0.25.0",
+ "gimli",
  "log",
  "regalloc",
  "smallvec",
@@ -128,31 +141,30 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976efb22fcab4f2cd6bd4e9913764616a54d895c1a23530128d04e03633c555f"
+checksum = "0f32ddb89e9b89d3d9b36a5b7d7ea3261c98235a76ac95ba46826b8ec40b1a24"
 dependencies = [
  "cranelift-codegen-shared",
- "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dabb5fe66e04d4652e434195b45ae65b5c8172d520247b8f66d8df42b2b45dc"
+checksum = "01fd0d9f288cc1b42d9333b7a776b17e278fc888c28e6a0f09b5573d45a150bc"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3329733e4d4b8e91c809efcaa4faee80bf66f20164e3dd16d707346bd3494799"
+checksum = "9e3bfe172b83167604601faf9dc60453e0d0a93415b57a9c4d1a7ae6849185cf"
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279afcc0d3e651b773f94837c3d581177b348c8d69e928104b2e9fccb226f921"
+checksum = "a006e3e32d80ce0e4ba7f1f9ddf66066d052a8c884a110b91d05404d6ce26dce"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -329,20 +341,14 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 dependencies = [
  "fallible-iterator",
  "indexmap",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "hashbrown"
@@ -746,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc"
-version = "0.0.31"
+version = "0.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
+checksum = "62446b1d3ebf980bdc68837700af1d77b37bc430e524bf95319c6eada2a4cc02"
 dependencies = [
  "log",
  "rustc-hash",
@@ -1112,9 +1118,9 @@ checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc7dff846db3f38f8ed0be4a009fdfeb729cf1f94a2c7fb6ff2fec01cefa110"
+checksum = "ea8d8361c9d006ea3d7797de7bd6b1492ffd0f91a22430cfda6c1658ad57bedf"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1124,6 +1130,7 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasm-bindgen",
+ "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-compiler-cranelift",
  "wasmer-derive",
@@ -1137,10 +1144,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmer-compiler"
-version = "2.2.0"
+name = "wasmer-artifact"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c91abf22b16dad3826ec0d0e3ec0a8304262a6c7a14e16528c536131b80e63d"
+checksum = "7aaf9428c29c1d8ad2ac0e45889ba8a568a835e33fd058964e5e500f2f7ce325"
+dependencies = [
+ "enumset",
+ "loupe",
+ "thiserror",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-compiler"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67a6cd866aed456656db2cfea96c18baabbd33f676578482b85c51e1ee19d2c"
 dependencies = [
  "enumset",
  "loupe",
@@ -1151,20 +1171,19 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasmer-types",
- "wasmer-vm",
  "wasmparser",
 ]
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7624a1f496b163139a7e0b442426cad805bec70486900287506f9d15a29323ab"
+checksum = "48be2f9f6495f08649e4f8b946a2cbbe119faf5a654aa1457f9504a99d23dae0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
- "gimli 0.25.0",
+ "gimli",
  "loupe",
  "more-asserts",
  "rayon",
@@ -1173,14 +1192,13 @@ dependencies = [
  "tracing",
  "wasmer-compiler",
  "wasmer-types",
- "wasmer-vm",
 ]
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "933b23b5cee0f58aa6c17c6de7e1f3007279357e0d555f22e24d6b395cfe7f89"
+checksum = "00e50405cc2a2f74ff574584710a5f2c1d5c93744acce2ca0866084739284b51"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1190,9 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41db0ac4df90610cda8320cfd5abf90c6ec90e298b6fe5a09a81dff718b55640"
+checksum = "3f98f010978c244db431b392aeab0661df7ea0822343334f8f2a920763548e45"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1205,6 +1223,7 @@ dependencies = [
  "serde_bytes",
  "target-lexicon",
  "thiserror",
+ "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-types",
  "wasmer-vm",
@@ -1212,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591683f3356ac31cc88aaecaf77ac2cc9f456014348b01af46c164f44f531162"
+checksum = "ad0358af9c154724587731175553805648d9acb8f6657880d165e378672b7e53"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1227,6 +1246,7 @@ dependencies = [
  "serde",
  "tempfile",
  "tracing",
+ "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-engine",
  "wasmer-object",
@@ -1237,12 +1257,11 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dccfde103e9b87427099a6de344b7c791574f307d035c8c7dbbc00974c1af0c1"
+checksum = "440dc3d93c9ca47865a4f4edd037ea81bf983b5796b59b3d712d844b32dbef15"
 dependencies = [
  "cfg-if",
- "enum-iterator",
  "enumset",
  "leb128",
  "loupe",
@@ -1250,16 +1269,33 @@ dependencies = [
  "rkyv",
  "wasmer-compiler",
  "wasmer-engine",
+ "wasmer-engine-universal-artifact",
  "wasmer-types",
  "wasmer-vm",
  "winapi",
 ]
 
 [[package]]
-name = "wasmer-object"
-version = "2.2.0"
+name = "wasmer-engine-universal-artifact"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0c4005592998bd840f2289102ef9c67b6138338ed78e1fc0809586aa229040"
+checksum = "68f1db3f54152657eb6e86c44b66525ff7801dad8328fe677da48dd06af9ad41"
+dependencies = [
+ "enum-iterator",
+ "enumset",
+ "loupe",
+ "rkyv",
+ "thiserror",
+ "wasmer-artifact",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-object"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d831335ff3a44ecf451303f6f891175c642488036b92ceceb24ac8623a8fa8b"
 dependencies = [
  "object",
  "thiserror",
@@ -1269,12 +1305,15 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4deb854f178265a76b59823c41547d259c65da3687b606b0b9c12d80ab950e3e"
+checksum = "39df01ea05dc0a9bab67e054c7cb01521e53b35a7bb90bd02eca564ed0b2667f"
 dependencies = [
+ "backtrace",
+ "enum-iterator",
  "indexmap",
  "loupe",
+ "more-asserts",
  "rkyv",
  "serde",
  "thiserror",
@@ -1282,32 +1321,37 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dbc5c989cb14a102433927e630473da52f83d82c469acd5cfa8fc7efacc1e70"
+checksum = "30d965fa61f4dc4cdb35a54daaf7ecec3563fbb94154a6c35433f879466247dd"
 dependencies = [
  "backtrace",
  "cc",
  "cfg-if",
+ "corosensei",
  "enum-iterator",
  "indexmap",
+ "lazy_static",
  "libc",
  "loupe",
+ "mach",
  "memoffset",
  "more-asserts",
  "region",
  "rkyv",
+ "scopeguard",
  "serde",
  "thiserror",
+ "wasmer-artifact",
  "wasmer-types",
  "winapi",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.78.2"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
+checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
 name = "wast"
@@ -1361,3 +1405,46 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43dbb096663629518eb1dfa72d80243ca5a6aca764cae62a2df70af760a9be75"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"

--- a/test/wasm_empty/Cargo.lock
+++ b/test/wasm_empty/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
- "gimli 0.26.1",
+ "gimli",
 ]
 
 [[package]]
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
@@ -101,25 +101,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cranelift-bforest"
-version = "0.76.0"
+name = "corosensei"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6bea67967505247f54fa2c85cf4f6e0e31c4e5692c9b70e4ae58e339067333"
+checksum = "9847f90f32a50b0dcbd68bc23ff242798b13080b97b0569f6ed96a45ce4cf2cd"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "libc",
+ "scopeguard",
+ "windows-sys",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.82.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38faa2a16616c8e78a18d37b4726b98bfd2de192f2fdc8a39ddf568a408a0f75"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48194035d2752bdd5bdae429e3ab88676e95f52a2b1355a5d4e809f9e39b1d74"
+checksum = "26f192472a3ba23860afd07d2b0217dc628f21fcc72617aa1336d98e1671f33b"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
  "cranelift-entity",
- "gimli 0.25.0",
+ "gimli",
  "log",
  "regalloc",
  "smallvec",
@@ -128,31 +141,30 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976efb22fcab4f2cd6bd4e9913764616a54d895c1a23530128d04e03633c555f"
+checksum = "0f32ddb89e9b89d3d9b36a5b7d7ea3261c98235a76ac95ba46826b8ec40b1a24"
 dependencies = [
  "cranelift-codegen-shared",
- "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dabb5fe66e04d4652e434195b45ae65b5c8172d520247b8f66d8df42b2b45dc"
+checksum = "01fd0d9f288cc1b42d9333b7a776b17e278fc888c28e6a0f09b5573d45a150bc"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3329733e4d4b8e91c809efcaa4faee80bf66f20164e3dd16d707346bd3494799"
+checksum = "9e3bfe172b83167604601faf9dc60453e0d0a93415b57a9c4d1a7ae6849185cf"
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279afcc0d3e651b773f94837c3d581177b348c8d69e928104b2e9fccb226f921"
+checksum = "a006e3e32d80ce0e4ba7f1f9ddf66066d052a8c884a110b91d05404d6ce26dce"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -329,20 +341,14 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 dependencies = [
  "fallible-iterator",
  "indexmap",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "hashbrown"
@@ -740,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc"
-version = "0.0.31"
+version = "0.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
+checksum = "62446b1d3ebf980bdc68837700af1d77b37bc430e524bf95319c6eada2a4cc02"
 dependencies = [
  "log",
  "rustc-hash",
@@ -1094,9 +1100,9 @@ checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc7dff846db3f38f8ed0be4a009fdfeb729cf1f94a2c7fb6ff2fec01cefa110"
+checksum = "ea8d8361c9d006ea3d7797de7bd6b1492ffd0f91a22430cfda6c1658ad57bedf"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1106,6 +1112,7 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasm-bindgen",
+ "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-compiler-cranelift",
  "wasmer-derive",
@@ -1119,10 +1126,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmer-compiler"
-version = "2.2.0"
+name = "wasmer-artifact"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c91abf22b16dad3826ec0d0e3ec0a8304262a6c7a14e16528c536131b80e63d"
+checksum = "7aaf9428c29c1d8ad2ac0e45889ba8a568a835e33fd058964e5e500f2f7ce325"
+dependencies = [
+ "enumset",
+ "loupe",
+ "thiserror",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-compiler"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67a6cd866aed456656db2cfea96c18baabbd33f676578482b85c51e1ee19d2c"
 dependencies = [
  "enumset",
  "loupe",
@@ -1133,20 +1153,19 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasmer-types",
- "wasmer-vm",
  "wasmparser",
 ]
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7624a1f496b163139a7e0b442426cad805bec70486900287506f9d15a29323ab"
+checksum = "48be2f9f6495f08649e4f8b946a2cbbe119faf5a654aa1457f9504a99d23dae0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
- "gimli 0.25.0",
+ "gimli",
  "loupe",
  "more-asserts",
  "rayon",
@@ -1155,14 +1174,13 @@ dependencies = [
  "tracing",
  "wasmer-compiler",
  "wasmer-types",
- "wasmer-vm",
 ]
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "933b23b5cee0f58aa6c17c6de7e1f3007279357e0d555f22e24d6b395cfe7f89"
+checksum = "00e50405cc2a2f74ff574584710a5f2c1d5c93744acce2ca0866084739284b51"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1172,9 +1190,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41db0ac4df90610cda8320cfd5abf90c6ec90e298b6fe5a09a81dff718b55640"
+checksum = "3f98f010978c244db431b392aeab0661df7ea0822343334f8f2a920763548e45"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1187,6 +1205,7 @@ dependencies = [
  "serde_bytes",
  "target-lexicon",
  "thiserror",
+ "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-types",
  "wasmer-vm",
@@ -1194,9 +1213,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591683f3356ac31cc88aaecaf77ac2cc9f456014348b01af46c164f44f531162"
+checksum = "ad0358af9c154724587731175553805648d9acb8f6657880d165e378672b7e53"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1209,6 +1228,7 @@ dependencies = [
  "serde",
  "tempfile",
  "tracing",
+ "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-engine",
  "wasmer-object",
@@ -1219,12 +1239,11 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dccfde103e9b87427099a6de344b7c791574f307d035c8c7dbbc00974c1af0c1"
+checksum = "440dc3d93c9ca47865a4f4edd037ea81bf983b5796b59b3d712d844b32dbef15"
 dependencies = [
  "cfg-if",
- "enum-iterator",
  "enumset",
  "leb128",
  "loupe",
@@ -1232,16 +1251,33 @@ dependencies = [
  "rkyv",
  "wasmer-compiler",
  "wasmer-engine",
+ "wasmer-engine-universal-artifact",
  "wasmer-types",
  "wasmer-vm",
  "winapi",
 ]
 
 [[package]]
-name = "wasmer-object"
-version = "2.2.0"
+name = "wasmer-engine-universal-artifact"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0c4005592998bd840f2289102ef9c67b6138338ed78e1fc0809586aa229040"
+checksum = "68f1db3f54152657eb6e86c44b66525ff7801dad8328fe677da48dd06af9ad41"
+dependencies = [
+ "enum-iterator",
+ "enumset",
+ "loupe",
+ "rkyv",
+ "thiserror",
+ "wasmer-artifact",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-object"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d831335ff3a44ecf451303f6f891175c642488036b92ceceb24ac8623a8fa8b"
 dependencies = [
  "object",
  "thiserror",
@@ -1251,12 +1287,15 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4deb854f178265a76b59823c41547d259c65da3687b606b0b9c12d80ab950e3e"
+checksum = "39df01ea05dc0a9bab67e054c7cb01521e53b35a7bb90bd02eca564ed0b2667f"
 dependencies = [
+ "backtrace",
+ "enum-iterator",
  "indexmap",
  "loupe",
+ "more-asserts",
  "rkyv",
  "serde",
  "thiserror",
@@ -1264,32 +1303,37 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dbc5c989cb14a102433927e630473da52f83d82c469acd5cfa8fc7efacc1e70"
+checksum = "30d965fa61f4dc4cdb35a54daaf7ecec3563fbb94154a6c35433f879466247dd"
 dependencies = [
  "backtrace",
  "cc",
  "cfg-if",
+ "corosensei",
  "enum-iterator",
  "indexmap",
+ "lazy_static",
  "libc",
  "loupe",
+ "mach",
  "memoffset",
  "more-asserts",
  "region",
  "rkyv",
+ "scopeguard",
  "serde",
  "thiserror",
+ "wasmer-artifact",
  "wasmer-types",
  "winapi",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.78.2"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
+checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
 name = "wast"
@@ -1343,3 +1387,46 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43dbb096663629518eb1dfa72d80243ca5a6aca764cae62a2df70af760a9be75"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"

--- a/test/wasm_io/Cargo.lock
+++ b/test/wasm_io/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
- "gimli 0.26.1",
+ "gimli",
 ]
 
 [[package]]
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
@@ -101,25 +101,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cranelift-bforest"
-version = "0.76.0"
+name = "corosensei"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6bea67967505247f54fa2c85cf4f6e0e31c4e5692c9b70e4ae58e339067333"
+checksum = "9847f90f32a50b0dcbd68bc23ff242798b13080b97b0569f6ed96a45ce4cf2cd"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "libc",
+ "scopeguard",
+ "windows-sys",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.82.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38faa2a16616c8e78a18d37b4726b98bfd2de192f2fdc8a39ddf568a408a0f75"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48194035d2752bdd5bdae429e3ab88676e95f52a2b1355a5d4e809f9e39b1d74"
+checksum = "26f192472a3ba23860afd07d2b0217dc628f21fcc72617aa1336d98e1671f33b"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
  "cranelift-entity",
- "gimli 0.25.0",
+ "gimli",
  "log",
  "regalloc",
  "smallvec",
@@ -128,31 +141,30 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976efb22fcab4f2cd6bd4e9913764616a54d895c1a23530128d04e03633c555f"
+checksum = "0f32ddb89e9b89d3d9b36a5b7d7ea3261c98235a76ac95ba46826b8ec40b1a24"
 dependencies = [
  "cranelift-codegen-shared",
- "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dabb5fe66e04d4652e434195b45ae65b5c8172d520247b8f66d8df42b2b45dc"
+checksum = "01fd0d9f288cc1b42d9333b7a776b17e278fc888c28e6a0f09b5573d45a150bc"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3329733e4d4b8e91c809efcaa4faee80bf66f20164e3dd16d707346bd3494799"
+checksum = "9e3bfe172b83167604601faf9dc60453e0d0a93415b57a9c4d1a7ae6849185cf"
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279afcc0d3e651b773f94837c3d581177b348c8d69e928104b2e9fccb226f921"
+checksum = "a006e3e32d80ce0e4ba7f1f9ddf66066d052a8c884a110b91d05404d6ce26dce"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -329,20 +341,14 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 dependencies = [
  "fallible-iterator",
  "indexmap",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "hashbrown"
@@ -768,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc"
-version = "0.0.31"
+version = "0.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
+checksum = "62446b1d3ebf980bdc68837700af1d77b37bc430e524bf95319c6eada2a4cc02"
 dependencies = [
  "log",
  "rustc-hash",
@@ -1135,9 +1141,9 @@ checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc7dff846db3f38f8ed0be4a009fdfeb729cf1f94a2c7fb6ff2fec01cefa110"
+checksum = "ea8d8361c9d006ea3d7797de7bd6b1492ffd0f91a22430cfda6c1658ad57bedf"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1147,6 +1153,7 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasm-bindgen",
+ "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-compiler-cranelift",
  "wasmer-derive",
@@ -1160,10 +1167,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmer-compiler"
-version = "2.2.0"
+name = "wasmer-artifact"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c91abf22b16dad3826ec0d0e3ec0a8304262a6c7a14e16528c536131b80e63d"
+checksum = "7aaf9428c29c1d8ad2ac0e45889ba8a568a835e33fd058964e5e500f2f7ce325"
+dependencies = [
+ "enumset",
+ "loupe",
+ "thiserror",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-compiler"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67a6cd866aed456656db2cfea96c18baabbd33f676578482b85c51e1ee19d2c"
 dependencies = [
  "enumset",
  "loupe",
@@ -1174,20 +1194,19 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasmer-types",
- "wasmer-vm",
  "wasmparser",
 ]
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7624a1f496b163139a7e0b442426cad805bec70486900287506f9d15a29323ab"
+checksum = "48be2f9f6495f08649e4f8b946a2cbbe119faf5a654aa1457f9504a99d23dae0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
- "gimli 0.25.0",
+ "gimli",
  "loupe",
  "more-asserts",
  "rayon",
@@ -1196,14 +1215,13 @@ dependencies = [
  "tracing",
  "wasmer-compiler",
  "wasmer-types",
- "wasmer-vm",
 ]
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "933b23b5cee0f58aa6c17c6de7e1f3007279357e0d555f22e24d6b395cfe7f89"
+checksum = "00e50405cc2a2f74ff574584710a5f2c1d5c93744acce2ca0866084739284b51"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1213,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41db0ac4df90610cda8320cfd5abf90c6ec90e298b6fe5a09a81dff718b55640"
+checksum = "3f98f010978c244db431b392aeab0661df7ea0822343334f8f2a920763548e45"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1228,6 +1246,7 @@ dependencies = [
  "serde_bytes",
  "target-lexicon",
  "thiserror",
+ "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-types",
  "wasmer-vm",
@@ -1235,9 +1254,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591683f3356ac31cc88aaecaf77ac2cc9f456014348b01af46c164f44f531162"
+checksum = "ad0358af9c154724587731175553805648d9acb8f6657880d165e378672b7e53"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1250,6 +1269,7 @@ dependencies = [
  "serde",
  "tempfile",
  "tracing",
+ "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-engine",
  "wasmer-object",
@@ -1260,12 +1280,11 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dccfde103e9b87427099a6de344b7c791574f307d035c8c7dbbc00974c1af0c1"
+checksum = "440dc3d93c9ca47865a4f4edd037ea81bf983b5796b59b3d712d844b32dbef15"
 dependencies = [
  "cfg-if",
- "enum-iterator",
  "enumset",
  "leb128",
  "loupe",
@@ -1273,16 +1292,33 @@ dependencies = [
  "rkyv",
  "wasmer-compiler",
  "wasmer-engine",
+ "wasmer-engine-universal-artifact",
  "wasmer-types",
  "wasmer-vm",
  "winapi",
 ]
 
 [[package]]
-name = "wasmer-object"
-version = "2.2.0"
+name = "wasmer-engine-universal-artifact"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0c4005592998bd840f2289102ef9c67b6138338ed78e1fc0809586aa229040"
+checksum = "68f1db3f54152657eb6e86c44b66525ff7801dad8328fe677da48dd06af9ad41"
+dependencies = [
+ "enum-iterator",
+ "enumset",
+ "loupe",
+ "rkyv",
+ "thiserror",
+ "wasmer-artifact",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-object"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d831335ff3a44ecf451303f6f891175c642488036b92ceceb24ac8623a8fa8b"
 dependencies = [
  "object",
  "thiserror",
@@ -1292,12 +1328,15 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4deb854f178265a76b59823c41547d259c65da3687b606b0b9c12d80ab950e3e"
+checksum = "39df01ea05dc0a9bab67e054c7cb01521e53b35a7bb90bd02eca564ed0b2667f"
 dependencies = [
+ "backtrace",
+ "enum-iterator",
  "indexmap",
  "loupe",
+ "more-asserts",
  "rkyv",
  "serde",
  "thiserror",
@@ -1305,32 +1344,37 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dbc5c989cb14a102433927e630473da52f83d82c469acd5cfa8fc7efacc1e70"
+checksum = "30d965fa61f4dc4cdb35a54daaf7ecec3563fbb94154a6c35433f879466247dd"
 dependencies = [
  "backtrace",
  "cc",
  "cfg-if",
+ "corosensei",
  "enum-iterator",
  "indexmap",
+ "lazy_static",
  "libc",
  "loupe",
+ "mach",
  "memoffset",
  "more-asserts",
  "region",
  "rkyv",
+ "scopeguard",
  "serde",
  "thiserror",
+ "wasmer-artifact",
  "wasmer-types",
  "winapi",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.78.2"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
+checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
 name = "wast"
@@ -1384,3 +1428,46 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43dbb096663629518eb1dfa72d80243ca5a6aca764cae62a2df70af760a9be75"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"

--- a/test/wasm_io/src/wasm.rs
+++ b/test/wasm_io/src/wasm.rs
@@ -87,5 +87,5 @@ macro_rules! _n {
     }
 }
 
-_n!(Bytes; n; vec![0; u32::from(n) as usize]; vec![];);
-_n!(String; n; ".".repeat(u32::from(n) as usize).to_string(); "".to_string(););
+_n!(Bytes; n; vec![0; u32::from(n).try_into().unwrap()]; vec![];);
+_n!(String; n; ".".repeat(u32::from(n).try_into().unwrap()).to_string(); "".to_string(););

--- a/test/wasm_memory/Cargo.lock
+++ b/test/wasm_memory/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
- "gimli 0.26.1",
+ "gimli",
 ]
 
 [[package]]
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
@@ -101,25 +101,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cranelift-bforest"
-version = "0.76.0"
+name = "corosensei"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6bea67967505247f54fa2c85cf4f6e0e31c4e5692c9b70e4ae58e339067333"
+checksum = "9847f90f32a50b0dcbd68bc23ff242798b13080b97b0569f6ed96a45ce4cf2cd"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "libc",
+ "scopeguard",
+ "windows-sys",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.82.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38faa2a16616c8e78a18d37b4726b98bfd2de192f2fdc8a39ddf568a408a0f75"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48194035d2752bdd5bdae429e3ab88676e95f52a2b1355a5d4e809f9e39b1d74"
+checksum = "26f192472a3ba23860afd07d2b0217dc628f21fcc72617aa1336d98e1671f33b"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
  "cranelift-entity",
- "gimli 0.25.0",
+ "gimli",
  "log",
  "regalloc",
  "smallvec",
@@ -128,31 +141,30 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976efb22fcab4f2cd6bd4e9913764616a54d895c1a23530128d04e03633c555f"
+checksum = "0f32ddb89e9b89d3d9b36a5b7d7ea3261c98235a76ac95ba46826b8ec40b1a24"
 dependencies = [
  "cranelift-codegen-shared",
- "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dabb5fe66e04d4652e434195b45ae65b5c8172d520247b8f66d8df42b2b45dc"
+checksum = "01fd0d9f288cc1b42d9333b7a776b17e278fc888c28e6a0f09b5573d45a150bc"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3329733e4d4b8e91c809efcaa4faee80bf66f20164e3dd16d707346bd3494799"
+checksum = "9e3bfe172b83167604601faf9dc60453e0d0a93415b57a9c4d1a7ae6849185cf"
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279afcc0d3e651b773f94837c3d581177b348c8d69e928104b2e9fccb226f921"
+checksum = "a006e3e32d80ce0e4ba7f1f9ddf66066d052a8c884a110b91d05404d6ce26dce"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -329,20 +341,14 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 dependencies = [
  "fallible-iterator",
  "indexmap",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "hashbrown"
@@ -768,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc"
-version = "0.0.31"
+version = "0.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
+checksum = "62446b1d3ebf980bdc68837700af1d77b37bc430e524bf95319c6eada2a4cc02"
 dependencies = [
  "log",
  "rustc-hash",
@@ -1135,9 +1141,9 @@ checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc7dff846db3f38f8ed0be4a009fdfeb729cf1f94a2c7fb6ff2fec01cefa110"
+checksum = "ea8d8361c9d006ea3d7797de7bd6b1492ffd0f91a22430cfda6c1658ad57bedf"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1147,6 +1153,7 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasm-bindgen",
+ "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-compiler-cranelift",
  "wasmer-derive",
@@ -1160,10 +1167,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmer-compiler"
-version = "2.2.0"
+name = "wasmer-artifact"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c91abf22b16dad3826ec0d0e3ec0a8304262a6c7a14e16528c536131b80e63d"
+checksum = "7aaf9428c29c1d8ad2ac0e45889ba8a568a835e33fd058964e5e500f2f7ce325"
+dependencies = [
+ "enumset",
+ "loupe",
+ "thiserror",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-compiler"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67a6cd866aed456656db2cfea96c18baabbd33f676578482b85c51e1ee19d2c"
 dependencies = [
  "enumset",
  "loupe",
@@ -1174,20 +1194,19 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasmer-types",
- "wasmer-vm",
  "wasmparser",
 ]
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7624a1f496b163139a7e0b442426cad805bec70486900287506f9d15a29323ab"
+checksum = "48be2f9f6495f08649e4f8b946a2cbbe119faf5a654aa1457f9504a99d23dae0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
- "gimli 0.25.0",
+ "gimli",
  "loupe",
  "more-asserts",
  "rayon",
@@ -1196,14 +1215,13 @@ dependencies = [
  "tracing",
  "wasmer-compiler",
  "wasmer-types",
- "wasmer-vm",
 ]
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "933b23b5cee0f58aa6c17c6de7e1f3007279357e0d555f22e24d6b395cfe7f89"
+checksum = "00e50405cc2a2f74ff574584710a5f2c1d5c93744acce2ca0866084739284b51"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1213,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41db0ac4df90610cda8320cfd5abf90c6ec90e298b6fe5a09a81dff718b55640"
+checksum = "3f98f010978c244db431b392aeab0661df7ea0822343334f8f2a920763548e45"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1228,6 +1246,7 @@ dependencies = [
  "serde_bytes",
  "target-lexicon",
  "thiserror",
+ "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-types",
  "wasmer-vm",
@@ -1235,9 +1254,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591683f3356ac31cc88aaecaf77ac2cc9f456014348b01af46c164f44f531162"
+checksum = "ad0358af9c154724587731175553805648d9acb8f6657880d165e378672b7e53"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1250,6 +1269,7 @@ dependencies = [
  "serde",
  "tempfile",
  "tracing",
+ "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-engine",
  "wasmer-object",
@@ -1260,12 +1280,11 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dccfde103e9b87427099a6de344b7c791574f307d035c8c7dbbc00974c1af0c1"
+checksum = "440dc3d93c9ca47865a4f4edd037ea81bf983b5796b59b3d712d844b32dbef15"
 dependencies = [
  "cfg-if",
- "enum-iterator",
  "enumset",
  "leb128",
  "loupe",
@@ -1273,16 +1292,33 @@ dependencies = [
  "rkyv",
  "wasmer-compiler",
  "wasmer-engine",
+ "wasmer-engine-universal-artifact",
  "wasmer-types",
  "wasmer-vm",
  "winapi",
 ]
 
 [[package]]
-name = "wasmer-object"
-version = "2.2.0"
+name = "wasmer-engine-universal-artifact"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0c4005592998bd840f2289102ef9c67b6138338ed78e1fc0809586aa229040"
+checksum = "68f1db3f54152657eb6e86c44b66525ff7801dad8328fe677da48dd06af9ad41"
+dependencies = [
+ "enum-iterator",
+ "enumset",
+ "loupe",
+ "rkyv",
+ "thiserror",
+ "wasmer-artifact",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-object"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d831335ff3a44ecf451303f6f891175c642488036b92ceceb24ac8623a8fa8b"
 dependencies = [
  "object",
  "thiserror",
@@ -1292,12 +1328,15 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4deb854f178265a76b59823c41547d259c65da3687b606b0b9c12d80ab950e3e"
+checksum = "39df01ea05dc0a9bab67e054c7cb01521e53b35a7bb90bd02eca564ed0b2667f"
 dependencies = [
+ "backtrace",
+ "enum-iterator",
  "indexmap",
  "loupe",
+ "more-asserts",
  "rkyv",
  "serde",
  "thiserror",
@@ -1305,32 +1344,37 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dbc5c989cb14a102433927e630473da52f83d82c469acd5cfa8fc7efacc1e70"
+checksum = "30d965fa61f4dc4cdb35a54daaf7ecec3563fbb94154a6c35433f879466247dd"
 dependencies = [
  "backtrace",
  "cc",
  "cfg-if",
+ "corosensei",
  "enum-iterator",
  "indexmap",
+ "lazy_static",
  "libc",
  "loupe",
+ "mach",
  "memoffset",
  "more-asserts",
  "region",
  "rkyv",
+ "scopeguard",
  "serde",
  "thiserror",
+ "wasmer-artifact",
  "wasmer-types",
  "winapi",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.78.2"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
+checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
 name = "wast"
@@ -1384,3 +1428,46 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43dbb096663629518eb1dfa72d80243ca5a6aca764cae62a2df70af760a9be75"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"

--- a/test/wasm_memory/src/wasm.rs
+++ b/test/wasm_memory/src/wasm.rs
@@ -11,12 +11,12 @@ extern "C" {
 #[no_mangle]
 pub extern "C" fn bytes_round_trip(_: GuestPtr, _: Len) -> GuestPtrLen {
 
-    let old_pages: WasmSize = unsafe { __pages(0) };
-    let _current_pages: WasmSize = old_pages;
+    let mut old_pages: WasmSize = unsafe { __pages(0) };
+    let mut current_pages: WasmSize = old_pages;
 
     // thrash this more times than there are bytes in a wasm page so that if even one byte leaks
     // we will see it in the page count
-    for _i in 0..100_000 {
+    for i in 0..100_000 {
 
         // thrash a bunch of little chunks of bytes so that we can be reasonably sure the
         // allocations are in the correct position and not overlapping
@@ -34,12 +34,12 @@ pub extern "C" fn bytes_round_trip(_: GuestPtr, _: Len) -> GuestPtrLen {
             );
         };
 
-        // // if we forget to deallocate properly then the number of allocated pages will grow
-        // old_pages = current_pages;
-        // current_pages = unsafe { __pages(0) };
-        // if i > 0 {
-        //     assert_eq!(old_pages, current_pages);
-        // }
+        // if we forget to deallocate properly then the number of allocated pages will grow
+        old_pages = current_pages;
+        current_pages = unsafe { __pages(0) };
+        if i > 0 {
+            assert_eq!(old_pages, current_pages);
+        }
     }
 
     return_ptr(())

--- a/test/wasm_memory/src/wasm.rs
+++ b/test/wasm_memory/src/wasm.rs
@@ -11,12 +11,12 @@ extern "C" {
 #[no_mangle]
 pub extern "C" fn bytes_round_trip(_: GuestPtr, _: Len) -> GuestPtrLen {
 
-    let mut old_pages: WasmSize = unsafe { __pages(0) };
-    let mut current_pages: WasmSize = old_pages;
+    let old_pages: WasmSize = unsafe { __pages(0) };
+    let _current_pages: WasmSize = old_pages;
 
     // thrash this more times than there are bytes in a wasm page so that if even one byte leaks
     // we will see it in the page count
-    for i in 0..100_000 {
+    for _i in 0..100_000 {
 
         // thrash a bunch of little chunks of bytes so that we can be reasonably sure the
         // allocations are in the correct position and not overlapping
@@ -34,12 +34,12 @@ pub extern "C" fn bytes_round_trip(_: GuestPtr, _: Len) -> GuestPtrLen {
             );
         };
 
-        // if we forget to deallocate properly then the number of allocated pages will grow
-        old_pages = current_pages;
-        current_pages = unsafe { __pages(0) };
-        if i > 0 {
-            assert_eq!(old_pages, current_pages);
-        }
+        // // if we forget to deallocate properly then the number of allocated pages will grow
+        // old_pages = current_pages;
+        // current_pages = unsafe { __pages(0) };
+        // if i > 0 {
+        //     assert_eq!(old_pages, current_pages);
+        // }
     }
 
     return_ptr(())

--- a/test/wasm_memory/src/wasm.rs
+++ b/test/wasm_memory/src/wasm.rs
@@ -30,7 +30,7 @@ pub extern "C" fn bytes_round_trip(_: GuestPtr, _: Len) -> GuestPtrLen {
             // consuming the bytes should give a vector of the same bytes as the original bytes
             assert_eq!(
                 bytes[i].to_vec(),
-                allocation::consume_bytes(ptrs[i], 5 as Len),
+                allocation::consume_bytes(ptrs[i], 5),
             );
         };
 


### PR DESCRIPTION
various cleanup in anticipation of audit

- easier macro for wasm error
- feature to switch between default wasm error being host/guest (default is guest)
- better docs
- use standard bit shifting for pointer/length handling between host/guest
- avoid almost all `as u32` and similar with explicit `try_from` instead to avoid any silently dropped bits
- add a "maybe corrupt" function for wasm errors that indicates an instance is not safe to reuse
- simplified allocation logic in the guest
- removed almost all panics
- bumped wasmer version