### PR TITLE
2023 01 17 extern version

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,8 +612,8 @@ macro on the guest side.
 
 - The host moves serialized `SomeDataType` on the host using the host allocator
 - The host calculates the `u32` length of the serialized data
-- The host asks the guest to `__allocate` the length
-- The guest (inside `__allocate`) allocates length bytes and returns a `GuestPtr` to the host
+- The host asks the guest to `__hc__allocate_1` the length
+- The guest (inside `__hc__allocate_1`) allocates length bytes and returns a `GuestPtr` to the host
 - The host checks that the `GuestPtr` + len bytes fits in the guest's memory bounds
 - The host writes the data into the guest memory
 - The host calls the function it wants to call in the guest, passing in the `GuestPtr` and `Len`
@@ -639,7 +639,7 @@ the `host::guest::call()` return value.
 - The `Result` bytes are leaked into the guest
 - The guest returns a `GuestPtrLen` to the host referencing the bytes
 - The host copies the bytes from `GuestPtrLen` and deserializes the `Result`
-- The host calls `__deallocate` so that the guest can cleanup the leaked data
+- The host calls `__hc__deallocate_1` so that the guest can cleanup the leaked data
 - The host deserializes the inner value if it makes sense to
 
 ##### Guest calling host

--- a/crates/guest/Cargo.toml
+++ b/crates/guest/Cargo.toml
@@ -19,4 +19,7 @@ holochain_wasmer_common = { version = "=0.0.82", path = "../common" }
 serde = "1"
 tracing = "0.1"
 parking_lot = "0.12"
+paste = "1.0"
+
+[dev-dependencies]
 test-fuzz = "=3.0.4"

--- a/crates/guest/src/allocation.rs
+++ b/crates/guest/src/allocation.rs
@@ -2,7 +2,7 @@
 /// Return the pointer to the leaked allocation so the host can write to it.
 #[no_mangle]
 #[inline(always)]
-pub extern "C" fn __allocate(len: usize) -> usize {
+pub extern "C" fn __hc__allocate_1(len: usize) -> usize {
     write_bytes(Vec::with_capacity(len))
 }
 
@@ -10,7 +10,7 @@ pub extern "C" fn __allocate(len: usize) -> usize {
 /// Needed because we leak memory every time we call `__allocate` and `write_bytes`.
 #[no_mangle]
 #[inline(always)]
-pub extern "C" fn __deallocate(guest_ptr: usize, len: usize) {
+pub extern "C" fn __hc__deallocate_1(guest_ptr: usize, len: usize) {
     let _ = consume_bytes(guest_ptr, len);
 }
 

--- a/crates/guest/src/guest.rs
+++ b/crates/guest/src/guest.rs
@@ -6,11 +6,21 @@ pub use holochain_wasmer_common::*;
 use crate::allocation::consume_bytes;
 use crate::allocation::write_bytes;
 
+pub use paste::paste;
+
 #[macro_export]
 macro_rules! host_externs {
-    ( $( $func_name:ident ),* ) => {
-        extern "C" {
-            $( pub fn $func_name(guest_allocation_ptr: usize, len: usize) -> $crate::DoubleUSize; )*
+    ( $( $func_name:ident:$version:literal ),* ) => {
+        $crate::paste! {
+            $(
+            #[no_mangle]
+            pub static [<__ $func_name __version>]: u64 = $version;
+            )*
+
+            #[no_mangle]
+            extern "C" {
+                $( pub fn [<__ $func_name _ $version>](guest_allocation_ptr: usize, len: usize) -> $crate::DoubleUSize; )*
+            }
         }
     };
 }

--- a/crates/guest/src/guest.rs
+++ b/crates/guest/src/guest.rs
@@ -12,14 +12,9 @@ pub use paste::paste;
 macro_rules! host_externs {
     ( $( $func_name:ident:$version:literal ),* ) => {
         $crate::paste! {
-            $(
-            #[no_mangle]
-            pub static [<__ $func_name __version>]: u64 = $version;
-            )*
-
             #[no_mangle]
             extern "C" {
-                $( pub fn [<__ $func_name _ $version>](guest_allocation_ptr: usize, len: usize) -> $crate::DoubleUSize; )*
+                $( pub fn [<__hc__ $func_name _ $version>](guest_allocation_ptr: usize, len: usize) -> $crate::DoubleUSize; )*
             }
         }
     };

--- a/crates/guest/src/guest.rs
+++ b/crates/guest/src/guest.rs
@@ -66,7 +66,7 @@ where
 
     let (output_guest_ptr, output_len): (usize, usize) = split_usize(unsafe {
         // This is unsafe because all host function calls in wasm are unsafe.
-        // The host will call `__deallocate` for us to free the leaked bytes from the input.
+        // The host will call `__hc__deallocate_1` for us to free the leaked bytes from the input.
         f(input_guest_ptr, input_len)
     })?;
 

--- a/crates/host/src/env.rs
+++ b/crates/host/src/env.rs
@@ -11,9 +11,9 @@ use wasmer::WasmerEnv;
 pub struct Env {
     #[wasmer(export)]
     memory: LazyInit<Memory>,
-    #[wasmer(export(name = "__allocate"))]
+    #[wasmer(export(name = "__hc__allocate_1"))]
     allocate: LazyInit<Function>,
-    #[wasmer(export(name = "__deallocate"))]
+    #[wasmer(export(name = "__hc__deallocate_1"))]
     deallocate: LazyInit<Function>,
 }
 

--- a/crates/host/src/guest.rs
+++ b/crates/host/src/guest.rs
@@ -155,7 +155,7 @@ where
     let guest_input_length_value: Value = Value::I32(guest_input_length);
     let (guest_input_ptr, guest_input_ptr_value) = match instance
         .exports
-        .get_function("__allocate")
+        .get_function("__hc__allocate_1")
         .map_err(|e| wasm_error!(WasmErrorInner::CallError(e.to_string())))?
         .call(&[guest_input_length_value.clone()])
         .map_err(|e| wasm_error!(WasmErrorInner::CallError(e.to_string())))?
@@ -171,7 +171,7 @@ where
         ),
         _ => {
             return Err(wasm_error!(WasmErrorInner::CallError(
-                "Not I32 return from __allocate".to_string()
+                "Not I32 return from __hc__allocate_1".to_string()
             ))
             .into())
         }
@@ -241,7 +241,7 @@ where
     // Tell the guest we are finished with the return pointer's data.
     instance
         .exports
-        .get_function("__deallocate")
+        .get_function("__hc__deallocate_1")
         .map_err(|e| wasm_error!(WasmErrorInner::CallError(e.to_string())))?
         .call(&[
             Value::I32(

--- a/test.sh
+++ b/test.sh
@@ -11,7 +11,7 @@ cargo clippy
 ( cd crates/guest && cargo clippy )
 
 # tests the root workspace that doesn't include any wasm code
-cargo test -- --nocapture
+cargo test ${1-} -- --nocapture
 
 # test that everything builds
 cargo build --release --manifest-path test/test_wasm/Cargo.toml --target wasm32-unknown-unknown

--- a/test/benches/bench.rs
+++ b/test/benches/bench.rs
@@ -42,27 +42,27 @@ pub fn wasm_instance(c: &mut Criterion) {
                 let env = Env::default();
                 let import_object: wasmer::ImportObject = imports! {
                     "env" => {
-                        "__short_circuit" => Function::new_native_with_env(
+                        "__hc__short_circuit_5" => Function::new_native_with_env(
                             module.store(),
                             env.clone(),
                             test::short_circuit
                         ),
-                        "__test_process_string" => Function::new_native_with_env(
+                        "__hc__test_process_string_2" => Function::new_native_with_env(
                             module.store(),
                             env.clone(),
                             test::test_process_string
                         ),
-                        "__test_process_struct" => Function::new_native_with_env(
+                        "__hc__test_process_struct_2" => Function::new_native_with_env(
                             module.store(),
                             env.clone(),
                             test::test_process_struct
                         ),
-                        "__debug" => Function::new_native_with_env(
+                        "__hc__debug_1" => Function::new_native_with_env(
                             module.store(),
                             env.clone(),
                             test::debug
                         ),
-                        "__pages" => Function::new_native_with_env(
+                        "__hc__pages_1" => Function::new_native_with_env(
                             module.store(),
                             env.clone(),
                             test::pages

--- a/test/src/import.rs
+++ b/test/src/import.rs
@@ -8,22 +8,22 @@ use holochain_wasmer_host::prelude::*;
 pub fn import_object(store: &Store, env: &Env) -> ImportObject {
     imports! {
         "env" => {
-            "__short_circuit" => Function::new_native_with_env(
+            "__short_circuit_5" => Function::new_native_with_env(
                 store,
                 env.clone(),
                 short_circuit
             ),
-            "__test_process_string" => Function::new_native_with_env(
+            "__test_process_string_2" => Function::new_native_with_env(
                 store,
                 env.clone(),
                 test_process_string
             ),
-            "__test_process_struct" => Function::new_native_with_env(
+            "__test_process_struct_2" => Function::new_native_with_env(
                 store,
                 env.clone(),
                 test_process_struct
             ),
-            "__debug" => Function::new_native_with_env(
+            "__debug_1" => Function::new_native_with_env(
                 store,
                 env.clone(),
                 debug

--- a/test/src/import.rs
+++ b/test/src/import.rs
@@ -8,27 +8,27 @@ use holochain_wasmer_host::prelude::*;
 pub fn import_object(store: &Store, env: &Env) -> ImportObject {
     imports! {
         "env" => {
-            "__short_circuit_5" => Function::new_native_with_env(
+            "__hc__short_circuit_5" => Function::new_native_with_env(
                 store,
                 env.clone(),
                 short_circuit
             ),
-            "__test_process_string_2" => Function::new_native_with_env(
+            "__hc__test_process_string_2" => Function::new_native_with_env(
                 store,
                 env.clone(),
                 test_process_string
             ),
-            "__test_process_struct_2" => Function::new_native_with_env(
+            "__hc__test_process_struct_2" => Function::new_native_with_env(
                 store,
                 env.clone(),
                 test_process_struct
             ),
-            "__debug_1" => Function::new_native_with_env(
+            "__hc__debug_1" => Function::new_native_with_env(
                 store,
                 env.clone(),
                 debug
             ),
-            "__pages" => Function::new_native_with_env(
+            "__hc__pages_1" => Function::new_native_with_env(
                 store,
                 env.clone(),
                 pages

--- a/test/src/test.rs
+++ b/test/src/test.rs
@@ -57,6 +57,16 @@ pub mod tests {
     }
 
     #[test]
+    fn host_externs_toolable() {
+        let module = TestWasm::Test.module(false);
+        dbg!(&module
+            .exports()
+            .globals()
+            .filter(|global| global.name().ends_with("__version"))
+            .collect::<Vec<_>>());
+    }
+
+    #[test]
     fn infinite_loop() {
         // Instead of looping forever we want the metering to kick in and trap
         // the execution into an unreachable error.

--- a/test/src/test.rs
+++ b/test/src/test.rs
@@ -59,11 +59,19 @@ pub mod tests {
     #[test]
     fn host_externs_toolable() {
         let module = TestWasm::Test.module(false);
-        dbg!(&module
-            .exports()
-            .globals()
-            .filter(|global| global.name().ends_with("__version"))
-            .collect::<Vec<_>>());
+        // Imports will be the minimal set of functions actually used by the wasm
+        // NOT the complete list defined by `host_externs!`.
+        assert_eq!(
+            vec![
+                "__hc__short_circuit_5".to_string(),
+                "__hc__test_process_string_2".to_string(),
+                "__hc__test_process_struct_2".to_string()
+            ],
+            module
+                .imports()
+                .map(|import| import.name().to_string())
+                .collect::<Vec<String>>()
+        );
     }
 
     #[test]

--- a/test/src/wasms.rs
+++ b/test/src/wasms.rs
@@ -45,17 +45,21 @@ impl TestWasm {
         }
     }
 
-    pub fn key(&self) -> [u8; 32] {
-        match self {
-            TestWasm::Empty => [0; 32],
-            TestWasm::Io => [1; 32],
-            TestWasm::Test => [2; 32],
-            TestWasm::Memory => [3; 32],
+    pub fn key(&self, metered: bool) -> [u8; 32] {
+        match (self, metered) {
+            (TestWasm::Empty, false) => [0; 32],
+            (TestWasm::Empty, true) => [1; 32],
+            (TestWasm::Io, false) => [2; 32],
+            (TestWasm::Io, true) => [3; 32],
+            (TestWasm::Test, false) => [4; 32],
+            (TestWasm::Test, true) => [5; 32],
+            (TestWasm::Memory, false) => [6; 32],
+            (TestWasm::Memory, true) => [7; 32],
         }
     }
 
     pub fn module(&self, metered: bool) -> Arc<Module> {
-        match MODULE_CACHE.write().get(self.key(), self.bytes()) {
+        match MODULE_CACHE.write().get(self.key(metered), self.bytes()) {
             Ok(v) => v,
             Err(runtime_error) => match runtime_error.downcast::<WasmError>() {
                 Ok(WasmError {
@@ -92,7 +96,7 @@ impl TestWasm {
                             .get()
                             .unwrap()
                             .write()
-                            .get(self.key(), self.bytes())
+                            .get(self.key(metered), self.bytes())
                             .unwrap(),
                     )
                 }

--- a/test/test_wasm/src/wasm.rs
+++ b/test/test_wasm/src/wasm.rs
@@ -16,7 +16,7 @@ host_externs!(
 
 #[no_mangle]
 pub extern "C" fn short_circuit(_guest_ptr: usize, _len: usize) -> DoubleUSize {
-    host_call::<(), String>(__short_circuit_5, ()).unwrap();
+    host_call::<(), String>(__hc__short_circuit_5, ()).unwrap();
     0
 }
 
@@ -33,11 +33,11 @@ pub extern "C" fn literal_bytes(guest_ptr: usize, len: usize) -> DoubleUSize {
 #[no_mangle]
 pub extern "C" fn ignore_args_process_string(guest_ptr: usize, len: usize) -> DoubleUSize {
     // A well behaved wasm must either use or deallocate the input.
-    // A malicious wasm can simply define a __deallocate function that does nothing.
+    // A malicious wasm can simply define a __hc__deallocate_1 function that does nothing.
     // The host has no way of knowing whether the guest is behaving right up until it leaks all available memory.
     // If the host tries to force deallocation it risks double-deallocating an honest guest.
-    crate::allocation::__deallocate(guest_ptr, len);
-    host_call::<&String, StringType>(__test_process_string_2, &"foo".into()).unwrap();
+    crate::allocation::__hc__deallocate_1(guest_ptr, len);
+    host_call::<&String, StringType>(__hc__test_process_string_2, &"foo".into()).unwrap();
     return_ptr(StringType::from(String::new()))
 }
 
@@ -52,8 +52,8 @@ pub extern "C" fn process_string(guest_ptr: usize, len: usize) -> DoubleUSize {
 
     let s: String = format!("guest: {}", String::from(s));
     let s: StringType = try_ptr!(
-        host_call::<&String, StringType>(__test_process_string_2, &s),
-        "could not __test_process_string"
+        host_call::<&String, StringType>(__hc__test_process_string_2, &s),
+        "could not __hc__test_process_string_2"
     );
     return_ptr(s)
 }
@@ -65,7 +65,7 @@ pub extern "C" fn process_native(guest_ptr: usize, len: usize) -> DoubleUSize {
         Err(err_ptr) => return err_ptr,
     };
     let processed: SomeStruct = try_ptr!(
-        host_call(__test_process_struct_2, &input),
+        host_call(__hc__test_process_struct_2, &input),
         "could not deserialize SomeStruct in process_native"
     );
     return_ptr(processed)

--- a/test/test_wasm/src/wasm.rs
+++ b/test/test_wasm/src/wasm.rs
@@ -6,17 +6,17 @@ use test_common::StringType;
 
 // define a few functions we expect the host to provide for us
 host_externs!(
-    __debug,
-    __noop,
-    __this_func_doesnt_exist_but_we_can_extern_it_anyway,
-    __test_process_string,
-    __test_process_struct,
-    __short_circuit
+    debug:1,
+    noop:1,
+    this_func_doesnt_exist_but_we_can_extern_it_anyway:1,
+    test_process_string:2,
+    test_process_struct:2,
+    short_circuit:5
 );
 
 #[no_mangle]
 pub extern "C" fn short_circuit(_guest_ptr: usize, _len: usize) -> DoubleUSize {
-    host_call::<(), String>(__short_circuit, ()).unwrap();
+    host_call::<(), String>(__short_circuit_5, ()).unwrap();
     0
 }
 
@@ -37,7 +37,7 @@ pub extern "C" fn ignore_args_process_string(guest_ptr: usize, len: usize) -> Do
     // The host has no way of knowing whether the guest is behaving right up until it leaks all available memory.
     // If the host tries to force deallocation it risks double-deallocating an honest guest.
     crate::allocation::__deallocate(guest_ptr, len);
-    host_call::<&String, StringType>(__test_process_string, &"foo".into()).unwrap();
+    host_call::<&String, StringType>(__test_process_string_2, &"foo".into()).unwrap();
     return_ptr(StringType::from(String::new()))
 }
 
@@ -52,7 +52,7 @@ pub extern "C" fn process_string(guest_ptr: usize, len: usize) -> DoubleUSize {
 
     let s: String = format!("guest: {}", String::from(s));
     let s: StringType = try_ptr!(
-        host_call::<&String, StringType>(__test_process_string, &s),
+        host_call::<&String, StringType>(__test_process_string_2, &s),
         "could not __test_process_string"
     );
     return_ptr(s)
@@ -65,7 +65,7 @@ pub extern "C" fn process_native(guest_ptr: usize, len: usize) -> DoubleUSize {
         Err(err_ptr) => return err_ptr,
     };
     let processed: SomeStruct = try_ptr!(
-        host_call(__test_process_struct, &input),
+        host_call(__test_process_struct_2, &input),
         "could not deserialize SomeStruct in process_native"
     );
     return_ptr(processed)

--- a/test/wasm_empty/Cargo.lock
+++ b/test/wasm_empty/Cargo.lock
@@ -537,8 +537,8 @@ dependencies = [
  "holochain_serialized_bytes",
  "holochain_wasmer_common",
  "parking_lot",
+ "paste",
  "serde",
- "test-fuzz",
  "tracing",
 ]
 

--- a/test/wasm_io/src/wasm.rs
+++ b/test/wasm_io/src/wasm.rs
@@ -7,7 +7,7 @@ macro_rules! _s {
             /// ignore the input completely and return empty data
             pub extern "C" fn [< $t:lower _input_ignored_empty_ret >](guest_ptr: usize, len: usize) -> DoubleUSize {
                 // Still need to deallocate the input even if we don't use it.
-                crate::allocation::__deallocate(guest_ptr, len);
+                crate::allocation::__hc__deallocate_1(guest_ptr, len);
                 return_ptr(
                     paste::expr! {
                         test_common::[< $t:camel Type >]::from($empty)

--- a/test/wasm_memory/src/wasm.rs
+++ b/test/wasm_memory/src/wasm.rs
@@ -1,7 +1,7 @@
 use holochain_wasmer_guest::*;
 
 host_externs!(
-    __debug
+    debug:1
 );
 
 extern "C" {

--- a/test/wasm_memory/src/wasm.rs
+++ b/test/wasm_memory/src/wasm.rs
@@ -5,13 +5,13 @@ host_externs!(
 );
 
 extern "C" {
-    pub fn __pages(i: u32) -> u32;
+    pub fn __hc__pages_1(i: u32) -> u32;
 }
 
 #[no_mangle]
 pub extern "C" fn bytes_round_trip(_: usize, _: usize) -> DoubleUSize {
 
-    let mut old_pages: WasmSize = unsafe { __pages(0) };
+    let mut old_pages: WasmSize = unsafe { __hc__pages_1(0) };
     let mut current_pages: WasmSize = old_pages;
 
     // thrash this more times than there are bytes in a wasm page so that if even one byte leaks
@@ -36,7 +36,7 @@ pub extern "C" fn bytes_round_trip(_: usize, _: usize) -> DoubleUSize {
 
         // if we forget to deallocate properly then the number of allocated pages will grow
         old_pages = current_pages;
-        current_pages = unsafe { __pages(0) };
+        current_pages = unsafe { __hc__pages_1(0) };
         if i > 0 {
             assert_eq!(old_pages, current_pages);
         }


### PR DESCRIPTION
this introduces `__hc__` prefix for imports and exports and also `_N` version suffix for both

arguably less useful for exports, but this paves the way for a host to inspect the guest via tooling, e.g. `module.imports()` and then interact with it different, e.g. for backwards compatibility, based on the version of the function that is provided/expected