### PR TITLE
Bump holochain-serialized-bytes version

### DIFF
--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -7,7 +7,7 @@ authors = [ "thedavidmeister", "thedavidmeister@gmail.com" ]
 edition = "2021"
 
 [dependencies]
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 serde = "1"
 thiserror = "1"
 serde_bytes = "0.11"

--- a/crates/guest/Cargo.toml
+++ b/crates/guest/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = [ "cdylib", "rlib" ]
 path = "src/guest.rs"
 
 [dependencies]
-holochain_serialized_bytes = { version = "=0.0.51", features = [] }
+holochain_serialized_bytes = { version = "=0.0.52", features = [] }
 holochain_wasmer_common = { version = "=0.0.84", path = "../common" }
 serde = "1"
 tracing = "0.1"

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 [dependencies]
 wasmer = "=2.3.0"
 holochain_wasmer_common = { version = "=0.0.84", path = "../common" }
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 serde = "1"
 tracing = "0.1"
 parking_lot = "0.12"


### PR DESCRIPTION
Why was this not bumped already, given HSB was already a version ahead?