### PR TITLE
ci: re-enable ci on windows with wasmer_wamr feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,8 +49,6 @@ jobs:
         wasmer-feature: 
           - "wasmer_sys_dev"
           - "wasmer_sys_prod"
-          # TODO Building with wasmer_wamr feature flag on windows is not currently working.
-          # See https://github.com/holochain/holochain-wasmer/issues/117
           - "wasmer_wamr"
     runs-on: windows-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,11 @@ jobs:
           LLVM_DIR=$(pwd)/${{ env.LLVM_DIR }}
           mkdir -p ${LLVM_DIR}
           curl --proto '=https' --tlsv1.2 -sSf "https://github.com/wasmerio/llvm-custom-builds/releases/download/18.x/llvm-windows-amd64.tar.xz" -L -o - | tar xJv -C ${LLVM_DIR}
+      - name: Install Ninja
+        uses: MinoruSekine/setup-scoop@v4.0.1
+        with:
+          buckets: extras
+          apps: ninja
       - name: test root
         shell: pwsh
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
           - "wasmer_sys_prod"
           # TODO Building with wasmer_wamr feature flag on windows is not currently working.
           # See https://github.com/holochain/holochain-wasmer/issues/117
-          # - "wasmer_wamr"
+          - "wasmer_wamr"
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Resolves #117

Wasmer 5.x fixed the setup for building the `wamr` feature on windows. This just adds the necessary build dep and re-adds it to CI.

I'd prefer to keep this in now since it works fine, even if we don't support `wasmer_wamr` on windows or choose to drop it from CI when an issue arises.