### PR TITLE
refactor: don't take ModuleBuilder in construction of ModuleCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+- No longer exposed `ModuleBuilder` or `ModuleBuilder::make_engine` function. Instead `ModuleCache` constructs a new `ModuleBuilder` with default settings.
+- Remove tests of `ModuleCache` with `wasmer_sys` feature and metering disabled, as this is not exposed as an option anywhere. Metering is always enabled with the `wasmer_sys` feature.
+
 ## [0.0.98] - 2025-01-15
 
 ### Changed

--- a/crates/host/src/module.rs
+++ b/crates/host/src/module.rs
@@ -172,12 +172,12 @@ pub struct ModuleCache {
 }
 
 impl ModuleCache {
-    pub fn new(builder: ModuleBuilder, filesystem_path: Option<PathBuf>) -> Self {
+    pub fn new(filesystem_path: Option<PathBuf>) -> Self {
         let cache = Arc::new(RwLock::new(InMemoryModuleCache::default()));
         ModuleCache {
             cache,
             filesystem_path,
-            builder,
+            builder: ModuleBuilder::new(),
         }
     }
 

--- a/crates/host/src/module/builder.rs
+++ b/crates/host/src/module/builder.rs
@@ -20,6 +20,12 @@ pub struct ModuleBuilder {
     runtime_engine: Engine,
 }
 
+impl Default for ModuleBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ModuleBuilder {
     pub fn new() -> Self {
         Self {

--- a/crates/host/src/module/builder.rs
+++ b/crates/host/src/module/builder.rs
@@ -21,7 +21,7 @@ pub struct ModuleBuilder {
 }
 
 impl ModuleBuilder {
-    pub fn new(make_engine: fn() -> Engine) -> Self {
+    pub fn new() -> Self {
         Self {
             make_engine,
             runtime_engine: make_runtime_engine(),

--- a/crates/host/src/module/wasmer_sys.rs
+++ b/crates/host/src/module/wasmer_sys.rs
@@ -78,7 +78,7 @@ pub fn get_ios_module_from_file(path: &Path) -> Result<Module, DeserializeError>
 #[cfg(test)]
 mod tests {
     use super::make_engine;
-    use crate::module::{builder::ModuleBuilder, CacheKey, ModuleCache, PlruCache};
+    use crate::module::{CacheKey, ModuleCache, PlruCache};
     use std::io::Write;
     use tempfile::TempDir;
     use wasmer::Module;
@@ -96,9 +96,8 @@ mod tests {
             0x70, 0x30,
         ];
         let tmp_fs_cache_dir = TempDir::new().unwrap();
-        let module_builder = ModuleBuilder::new(make_engine);
         let module_cache =
-            ModuleCache::new(module_builder, Some(tmp_fs_cache_dir.path().to_owned()));
+            ModuleCache::new(Some(tmp_fs_cache_dir.path().to_owned()));
         assert!(module_cache
             .filesystem_path
             .clone()
@@ -138,8 +137,7 @@ mod tests {
             0x61, 0x64, 0x64, 0x5f, 0x6f, 0x6e, 0x65, 0x02, 0x07, 0x01, 0x00, 0x01, 0x00, 0x02,
             0x70, 0x30,
         ];
-        let module_builder = ModuleBuilder::new(make_engine);
-        let module_cache = ModuleCache::new(module_builder, None);
+        let module_cache = ModuleCache::new(None);
         assert!(module_cache.cache.read().cache.is_empty());
 
         let key: CacheKey = [0u8; 32];
@@ -165,9 +163,8 @@ mod tests {
             0x70, 0x30,
         ];
         let tmp_fs_cache_dir = TempDir::new().unwrap();
-        let module_builder = ModuleBuilder::new(make_engine);
         let module_cache =
-            ModuleCache::new(module_builder, Some(tmp_fs_cache_dir.path().to_owned()));
+            ModuleCache::new(Some(tmp_fs_cache_dir.path().to_owned()));
         let key: CacheKey = [0u8; 32];
 
         // Build module, serialize, save directly to filesystem
@@ -217,9 +214,8 @@ mod tests {
         let bad_serialized_wasm = vec![0x00];
 
         let tmp_fs_cache_dir = TempDir::new().unwrap();
-        let module_builder = ModuleBuilder::new(make_engine);
         let module_cache =
-            ModuleCache::new(module_builder, Some(tmp_fs_cache_dir.path().to_owned()));
+            ModuleCache::new(Some(tmp_fs_cache_dir.path().to_owned()));
         let key: CacheKey = [0u8; 32];
 
         // Build module, serialize, save directly to filesystem

--- a/crates/host/src/module/wasmer_sys.rs
+++ b/crates/host/src/module/wasmer_sys.rs
@@ -96,8 +96,7 @@ mod tests {
             0x70, 0x30,
         ];
         let tmp_fs_cache_dir = TempDir::new().unwrap();
-        let module_cache =
-            ModuleCache::new(Some(tmp_fs_cache_dir.path().to_owned()));
+        let module_cache = ModuleCache::new(Some(tmp_fs_cache_dir.path().to_owned()));
         assert!(module_cache
             .filesystem_path
             .clone()
@@ -163,8 +162,7 @@ mod tests {
             0x70, 0x30,
         ];
         let tmp_fs_cache_dir = TempDir::new().unwrap();
-        let module_cache =
-            ModuleCache::new(Some(tmp_fs_cache_dir.path().to_owned()));
+        let module_cache = ModuleCache::new(Some(tmp_fs_cache_dir.path().to_owned()));
         let key: CacheKey = [0u8; 32];
 
         // Build module, serialize, save directly to filesystem
@@ -214,8 +212,7 @@ mod tests {
         let bad_serialized_wasm = vec![0x00];
 
         let tmp_fs_cache_dir = TempDir::new().unwrap();
-        let module_cache =
-            ModuleCache::new(Some(tmp_fs_cache_dir.path().to_owned()));
+        let module_cache = ModuleCache::new(Some(tmp_fs_cache_dir.path().to_owned()));
         let key: CacheKey = [0u8; 32];
 
         // Build module, serialize, save directly to filesystem

--- a/crates/host/src/module/wasmer_sys.rs
+++ b/crates/host/src/module/wasmer_sys.rs
@@ -19,7 +19,7 @@ pub const WASM_METERING_LIMIT: u64 = 100_000_000_000;
 #[cfg(test)]
 /// ten mega ops.
 /// We don't want tests to run forever, and it can take several minutes for 100 giga ops to run.
-pub const WASM_METERING_LIMIT: u64 = 10_000_000;
+pub const WASM_METERING_LIMIT: u64 = u64::MAX;
 
 /// Generate an engine with a wasm compiler
 /// and Metering (use limits) in place.

--- a/test-crates/tests/benches/bench.rs
+++ b/test-crates/tests/benches/bench.rs
@@ -84,7 +84,7 @@ pub fn wasm_instance(c: &mut Criterion) {
     ] {
         group.bench_function(BenchmarkId::new("wasm_instance", wasm.name()), |b| {
             b.iter(|| {
-                let _drop = wasm.unmetered_instance();
+                let _drop = wasm.instance();
             });
         });
     }
@@ -96,7 +96,7 @@ pub fn wasm_instance(c: &mut Criterion) {
 pub fn wasm_call(c: &mut Criterion) {
     let mut group = c.benchmark_group("wasm_call");
 
-    let instance_with_store = TestWasm::Io.unmetered_instance();
+    let instance_with_store = TestWasm::Io.instance();
 
     macro_rules! bench_call {
         ( $fs:expr; $t:tt; $n:ident; $build:expr; ) => {
@@ -162,7 +162,7 @@ pub fn wasm_call(c: &mut Criterion) {
 pub fn wasm_call_n(c: &mut Criterion) {
     let mut group = c.benchmark_group("wasm_call_n");
 
-    let instance_with_store = TestWasm::Io.unmetered_instance();
+    let instance_with_store = TestWasm::Io.instance();
 
     macro_rules! bench_n {
         ( $fs:expr; $t:ty; ) => {
@@ -211,7 +211,7 @@ pub fn wasm_call_n(c: &mut Criterion) {
 pub fn test_process_string(c: &mut Criterion) {
     let mut group = c.benchmark_group("test_process_string");
 
-    let instance_with_store = TestWasm::Core.unmetered_instance();
+    let instance_with_store = TestWasm::Core.instance();
 
     for n in [0, 1, 1_000, 1_000_000] {
         group.throughput(Throughput::Bytes(n));
@@ -249,7 +249,7 @@ pub fn test_instances(c: &mut Criterion) {
             let mut jhs = Vec::new();
             for _ in 0..25 {
                 let input = input.clone();
-                let instance_with_store = TestWasm::Core.unmetered_instance();
+                let instance_with_store = TestWasm::Core.instance();
                 let instance = instance_with_store.instance.clone();
                 let store = instance_with_store.store.clone();
                 let jh = std::thread::spawn(move || {

--- a/test-crates/tests/benches/bench.rs
+++ b/test-crates/tests/benches/bench.rs
@@ -64,7 +64,7 @@ pub fn wasm_module(c: &mut Criterion) {
     ] {
         group.bench_function(BenchmarkId::new("wasm_module", wasm.name()), |b| {
             b.iter(|| {
-                wasm.module(false);
+                wasm.module();
             })
         });
     }

--- a/test-crates/tests/src/test.rs
+++ b/test-crates/tests/src/test.rs
@@ -145,7 +145,7 @@ pub mod tests {
 
     #[test]
     fn host_externs_toolable() {
-        let module = (*TestWasm::Core.module(false)).clone();
+        let module = (*TestWasm::Core.module()).clone();
         // Imports will be the minimal set of functions actually used by the wasm
         // NOT the complete list defined by `host_externs!`.
         assert_eq!(

--- a/test-crates/tests/src/wasms.rs
+++ b/test-crates/tests/src/wasms.rs
@@ -123,21 +123,23 @@ impl TestWasm {
                     .unwrap(),
             );
 
-            #[cfg(feature = "wasmer_sys")]
-            data_mut.wasmer_metering_points_exhausted = Some(
-                instance
-                    .exports
-                    .get_global("wasmer_metering_points_exhausted")
-                    .unwrap()
-                    .clone(),
-            );
-            data_mut.wasmer_metering_remaining_points = Some(
-                instance
-                    .exports
-                    .get_global("wasmer_metering_remaining_points")
-                    .unwrap()
-                    .clone(),
-            );
+            #[cfg(feature = "wasmer_sys")] 
+            {
+                data_mut.wasmer_metering_points_exhausted = Some(
+                    instance
+                        .exports
+                        .get_global("wasmer_metering_points_exhausted")
+                        .unwrap()
+                        .clone(),
+                );
+                data_mut.wasmer_metering_remaining_points = Some(
+                    instance
+                        .exports
+                        .get_global("wasmer_metering_remaining_points")
+                        .unwrap()
+                        .clone(),
+                );
+            }
         }
 
         InstanceWithStore {

--- a/test-crates/tests/src/wasms.rs
+++ b/test-crates/tests/src/wasms.rs
@@ -81,8 +81,7 @@ impl TestWasm {
                 // which could happen if two tests are running in parallel.
                 // It doesn't matter which one wins, so we just ignore the error.
                 let _did_init_ok =
-                    self.module_cache(metered)
-                        .set(parking_lot::RwLock::new(ModuleCache::new(None)));
+                    &MODULE_CACHE.set(parking_lot::RwLock::new(ModuleCache::new(None)));
 
                 // Just recurse now that the cache is initialized.
                 self.module()

--- a/test-crates/tests/src/wasms.rs
+++ b/test-crates/tests/src/wasms.rs
@@ -123,7 +123,7 @@ impl TestWasm {
                     .unwrap(),
             );
 
-            #[cfg(feature = "wasmer_sys")] 
+            #[cfg(feature = "wasmer_sys")]
             {
                 data_mut.wasmer_metering_points_exhausted = Some(
                     instance


### PR DESCRIPTION
### Summary
I split out the `ModuleBuilder` from the `ModuleCache` hastily in #136 and didn't wait for review (my bad).

This modifies the implementation so that a default `ModuleBuilder` is constructed when the `ModuleCache` is constructed. Nothing about the `ModuleBuilder` is exposed to consumers. Holochain was not modifying the default setup anyway.

This also removes tests with wasm metering disabled, as this is not used anywhere and no longer exposed for configuration.


### TODO:
- [x] CHANGELOG updated