### PR TITLE
feat: 2 constructors for ModuleCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+- Modify the `ModuleCache::new` constructor to no longer take a `ModuleBuilder` parameter.
+- Add a `ModuleCache::new_with_builder` constructor which does take a `ModuleBuilder` parameter.
+
 ## [0.0.98] - 2025-01-15
 
 ### Changed

--- a/crates/host/src/module.rs
+++ b/crates/host/src/module.rs
@@ -172,7 +172,13 @@ pub struct ModuleCache {
 }
 
 impl ModuleCache {
-    pub fn new(builder: ModuleBuilder, filesystem_path: Option<PathBuf>) -> Self {
+    /// Construct a ModuleCache with the default ModuleBuilder
+    pub fn new(filesystem_path: Option<PathBuf>) -> Self {
+        Self::new_with_builder(ModuleBuilder::new(make_engine), filesystem_path)
+    }
+
+    /// Construct a ModuleCache with a custom ModuleBuilder
+    pub fn new_with_builder(builder: ModuleBuilder, filesystem_path: Option<PathBuf>) -> Self {
         let cache = Arc::new(RwLock::new(InMemoryModuleCache::default()));
         ModuleCache {
             cache,

--- a/crates/host/src/module/wasmer_sys.rs
+++ b/crates/host/src/module/wasmer_sys.rs
@@ -78,7 +78,7 @@ pub fn get_ios_module_from_file(path: &Path) -> Result<Module, DeserializeError>
 #[cfg(test)]
 mod tests {
     use super::make_engine;
-    use crate::module::{builder::ModuleBuilder, CacheKey, ModuleCache, PlruCache};
+    use crate::module::{CacheKey, ModuleCache, PlruCache};
     use std::io::Write;
     use tempfile::TempDir;
     use wasmer::Module;
@@ -96,9 +96,7 @@ mod tests {
             0x70, 0x30,
         ];
         let tmp_fs_cache_dir = TempDir::new().unwrap();
-        let module_builder = ModuleBuilder::new(make_engine);
-        let module_cache =
-            ModuleCache::new(module_builder, Some(tmp_fs_cache_dir.path().to_owned()));
+        let module_cache = ModuleCache::new(Some(tmp_fs_cache_dir.path().to_owned()));
         assert!(module_cache
             .filesystem_path
             .clone()
@@ -138,8 +136,7 @@ mod tests {
             0x61, 0x64, 0x64, 0x5f, 0x6f, 0x6e, 0x65, 0x02, 0x07, 0x01, 0x00, 0x01, 0x00, 0x02,
             0x70, 0x30,
         ];
-        let module_builder = ModuleBuilder::new(make_engine);
-        let module_cache = ModuleCache::new(module_builder, None);
+        let module_cache = ModuleCache::new(None);
         assert!(module_cache.cache.read().cache.is_empty());
 
         let key: CacheKey = [0u8; 32];
@@ -165,9 +162,7 @@ mod tests {
             0x70, 0x30,
         ];
         let tmp_fs_cache_dir = TempDir::new().unwrap();
-        let module_builder = ModuleBuilder::new(make_engine);
-        let module_cache =
-            ModuleCache::new(module_builder, Some(tmp_fs_cache_dir.path().to_owned()));
+        let module_cache = ModuleCache::new(Some(tmp_fs_cache_dir.path().to_owned()));
         let key: CacheKey = [0u8; 32];
 
         // Build module, serialize, save directly to filesystem
@@ -217,9 +212,7 @@ mod tests {
         let bad_serialized_wasm = vec![0x00];
 
         let tmp_fs_cache_dir = TempDir::new().unwrap();
-        let module_builder = ModuleBuilder::new(make_engine);
-        let module_cache =
-            ModuleCache::new(module_builder, Some(tmp_fs_cache_dir.path().to_owned()));
+        let module_cache = ModuleCache::new(Some(tmp_fs_cache_dir.path().to_owned()));
         let key: CacheKey = [0u8; 32];
 
         // Build module, serialize, save directly to filesystem

--- a/test-crates/tests/src/wasms.rs
+++ b/test-crates/tests/src/wasms.rs
@@ -116,16 +116,16 @@ impl TestWasm {
                 // This will error if the cache is already initialized
                 // which could happen if two tests are running in parallel.
                 // It doesn't matter which one wins, so we just ignore the error.
-                let _did_init_ok =
-                    self.module_cache(metered)
-                        .set(parking_lot::RwLock::new(ModuleCache::new(
-                            ModuleBuilder::new(if metered {
-                                cranelift_fn
-                            } else {
-                                compiler_fn_unmetered
-                            }),
-                            None,
-                        )));
+                let _did_init_ok = self.module_cache(metered).set(parking_lot::RwLock::new(
+                    ModuleCache::new_with_builder(
+                        ModuleBuilder::new(if metered {
+                            cranelift_fn
+                        } else {
+                            compiler_fn_unmetered
+                        }),
+                        None,
+                    ),
+                ));
 
                 // Just recurse now that the cache is initialized.
                 self.module(metered)


### PR DESCRIPTION
### Summary
I added the `ModuleBuilder` hastily in #136 and didn't wait for review (my fault). I ran into this issue when integrating with holochain that the `make_engine` needed to construct a `ModuleBuilder` is no longer public.

This modifies `ModuleCache` to have 2 constructors. `ModuleCache::new` does not take a `ModuleBuilder` and constructs one, while `ModuleCache::new_with_builder` does. The latter is only used internally for running benchmarks where metering is disabled.

### TODO:
- [x] CHANGELOG updated