### PR TITLE
Chore/remove unsued ios bundling fns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-- **BREAKING CHANGE** Functions that are no longer used by holochain have been removed: `build_ios_module` and `get_ios_module_from_file`. Their only use was deprecated in holochain 0.4 and has been removed in 0.5.
+- **BREAKING CHANGE** Functions that are no longer used by holochain have been removed: `build_ios_module` and `get_ios_module_from_file`. Their only use was deprecated in holochain 0.5 and has been removed in 0.6.
 
 ## [0.0.99] - 2025-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+- **BREAKING CHANGE** Functions that are no longer used by holochain have been removed: `build_ios_module` and `get_ios_module_from_file`. Their only use was deprecated in holochain 0.4 and has been removed in 0.5.
+
 ## [0.0.99] - 2025-01-16
 
 - Modify the `ModuleCache::new` constructor to no longer take a `ModuleBuilder` parameter.

--- a/crates/host/src/module/wasmer_sys.rs
+++ b/crates/host/src/module/wasmer_sys.rs
@@ -1,15 +1,10 @@
-use std::path::Path;
 use std::sync::Arc;
-use tracing::info;
 use wasmer::sys::BaseTunables;
 use wasmer::sys::CompilerConfig;
 use wasmer::wasmparser;
-use wasmer::CompileError;
-use wasmer::DeserializeError;
 use wasmer::Engine;
 use wasmer::Module;
 use wasmer::NativeEngineExt;
-use wasmer::Store;
 use wasmer_middlewares::Metering;
 
 #[cfg(not(test))]
@@ -57,22 +52,6 @@ pub(crate) fn make_runtime_engine() -> Engine {
 /// Build an interpreter module from wasm bytes.
 pub fn build_module(_wasm: &[u8]) -> Result<Arc<Module>, wasmer::RuntimeError> {
     unimplemented!("The feature flag 'wasmer_wamr' must be enabled to support building a Module directly. Please use the ModuleCache instead.");
-}
-
-/// Take WASM binary and prepare a wasmer Module suitable for iOS
-pub fn build_ios_module(wasm: &[u8]) -> Result<Module, CompileError> {
-    info!(
-        "Found wasm and was instructed to serialize it for ios in wasmer format, doing so now..."
-    );
-    let compiler_engine = make_engine();
-    let store = Store::new(compiler_engine);
-    Module::from_binary(&store, wasm)
-}
-
-/// Deserialize a previously compiled module for iOS from a file.
-pub fn get_ios_module_from_file(path: &Path) -> Result<Module, DeserializeError> {
-    let engine = Engine::headless();
-    unsafe { Module::deserialize_from_file(&engine, path) }
 }
 
 #[cfg(test)]

--- a/crates/host/src/module/wasmer_wamr.rs
+++ b/crates/host/src/module/wasmer_wamr.rs
@@ -25,16 +25,6 @@ pub fn build_module(wasm: &[u8]) -> Result<Arc<Module>, wasmer::RuntimeError> {
     Ok(Arc::new(module))
 }
 
-/// Take WASM binary and prepare a wasmer Module suitable for iOS
-pub fn build_ios_module(_wasm: &[u8]) -> Result<Module, CompileError> {
-    unimplemented!("The feature flag 'wasmer_sys' must be enabled to support compiling wasm");
-}
-
-/// Deserialize a previously compiled module for iOS from a file.
-pub fn get_ios_module_from_file(_path: &Path) -> Result<Module, DeserializeError> {
-    unimplemented!("The feature flag 'wasmer_sys' must be enabled to support compiling wasm");
-}
-
 #[cfg(test)]
 mod tests {
     use super::build_module;

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "cargo-chef": {
       "flake": false,
       "locked": {
-        "lastModified": 1716357509,
-        "narHash": "sha256-7iSxwTaJnDLqaFu4ydxkx7ivhDvSQQcXWKawv/e4NHE=",
+        "lastModified": 1727084300,
+        "narHash": "sha256-ya6hQXFDWMvb265v7vktRcc/kVb833vmq8Z9ArM70F0=",
         "owner": "LukeMathWalker",
         "repo": "cargo-chef",
-        "rev": "b468537839bfc7c23d744b85d7a5090954626550",
+        "rev": "a228626f314d3aacd21723b49dd5cc4257d3f716",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1725125250,
-        "narHash": "sha256-CB20rDD5eHikF6mMTTJdwPP1qvyoiyyw1RDUzwIaIF8=",
+        "lastModified": 1732407143,
+        "narHash": "sha256-qJOGDT6PACoX+GbNH2PPx2ievlmtT1NVeTB80EkRLys=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "96fd12c7100e9e05fa1a0a5bd108525600ce282f",
+        "rev": "f2b4b472983817021d9ffb60838b2b36b9376b20",
         "type": "github"
       },
       "original": {
@@ -68,11 +68,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1732722421,
+        "narHash": "sha256-HRJ/18p+WoXpWJkcdsk9St5ZiukCqSDgbOGFa8Okehg=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "9ed2ac151eada2306ca8c418ebd97807bb08f6ac",
         "type": "github"
       },
       "original": {
@@ -86,11 +86,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1725234343,
-        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
+        "lastModified": 1730504689,
+        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
+        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
         "type": "github"
       },
       "original": {
@@ -101,16 +101,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1730855012,
-        "narHash": "sha256-oW4d2DRHxktRkkGbilWL8ZufXfA3vGeMXLnLgi12Ewk=",
+        "lastModified": 1741007205,
+        "narHash": "sha256-t3L5PrXSfq+47cvDQgJMxZ+W7q2UNhkKRiAZuMv//Lo=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "525b63fb019eac866e096033ba194c2d8bb45b9a",
+        "rev": "5025fb1c3969f9284e31511889e88cabed933ffe",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.5.0-dev.4",
+        "ref": "holochain-0.5.0-dev.21",
         "repo": "holochain",
         "type": "github"
       }
@@ -149,11 +149,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731093440,
-        "narHash": "sha256-+k2JYY9hCBcKHWxj3iq7duAtzXL2KTC73YA8O9fhObU=",
+        "lastModified": 1744721899,
+        "narHash": "sha256-QYJ32l5cw8sxuEXMSPPv4iXe8zwDWidSeyuvAtH/jvE=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "37cd2b92addb41382c4c6b3680e39d264d039b63",
+        "rev": "53a2122b07427d835aabc9d0cf070694afaff030",
         "type": "github"
       },
       "original": {
@@ -165,16 +165,16 @@
     "lair": {
       "flake": false,
       "locked": {
-        "lastModified": 1726865440,
-        "narHash": "sha256-+ARQs+Sfmh8QXMyjjHjm6Ib8Ag86Jm2vnyB6l3zTCgA=",
+        "lastModified": 1732721902,
+        "narHash": "sha256-D8sXIpOptaXib5bc6zS7KsGzu4D08jaL8Fx1W/mlADE=",
         "owner": "holochain",
         "repo": "lair",
-        "rev": "9f306efed597765b70da704e1739ecc67f2510e0",
+        "rev": "e82937521ae9b7bdb30c8b0736c13cd4220a0223",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "lair_keystore-v0.5.2",
+        "ref": "lair_keystore-v0.5.3",
         "repo": "lair",
         "type": "github"
       }
@@ -198,11 +198,11 @@
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1710156097,
-        "narHash": "sha256-1Wvk8UP7PXdf8bCCaEoMnOT1qe5/Duqgj+rL8sRQsSM=",
+        "lastModified": 1731533336,
+        "narHash": "sha256-oRam5PS1vcrr5UPgALW0eo1m/5/pls27Z/pabHNy2Ms=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "3342559a24e85fc164b295c3444e8a139924675b",
+        "rev": "f7653272fd234696ae94229839a99b73c9ab7de0",
         "type": "github"
       },
       "original": {
@@ -213,11 +213,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728018373,
-        "narHash": "sha256-NOiTvBbRLIOe5F6RbHaAh6++BNjsb149fGZd1T4+KBg=",
+        "lastModified": 1739580444,
+        "narHash": "sha256-+/bSz4EAVbqz8/HsIGLroF8aNaO8bLRL7WfACN+24g4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bc947f541ae55e999ffdb4013441347d83b00feb",
+        "rev": "8bb37161a0488b89830168b81c48aed11569cb93",
         "type": "github"
       },
       "original": {
@@ -228,24 +228,24 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1725233747,
-        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
+        "lastModified": 1730504152,
+        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       }
     },
     "pre-commit-hooks-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1724857454,
-        "narHash": "sha256-Qyl9Q4QMTLZnnBb/8OuQ9LSkzWjBU1T5l5zIzTxkkhk=",
+        "lastModified": 1732021966,
+        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "4509ca64f1084e73bc7a721b20c669a8d4c5ebe6",
+        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
         "type": "github"
       },
       "original": {
@@ -284,11 +284,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728181869,
-        "narHash": "sha256-sQXHXsjIcGEoIHkB+RO6BZdrPfB+43V1TEpyoWRI3ww=",
+        "lastModified": 1744513456,
+        "narHash": "sha256-NLVluTmK8d01Iz+WyarQhwFcXpHEwU7m5hH3YQQFJS0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "cd46aa3906c14790ef5cbe278d9e54f2c38f95c0",
+        "rev": "730fd8e82799219754418483fabe1844262fd1e2",
         "type": "github"
       },
       "original": {
@@ -300,11 +300,11 @@
     "scaffolding": {
       "flake": false,
       "locked": {
-        "lastModified": 1730407032,
-        "narHash": "sha256-NNnow8Cne1KBJ4WvJ6eT1OzcqyJiii35Q2ElVdI0ozA=",
+        "lastModified": 1738683444,
+        "narHash": "sha256-nLCdB9Gs09XLcfXYuLPfAhyuuZylg/011WoAL1fomTE=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "f838294a3c4f45b3e8e41297ea36eb91cfedee80",
+        "rev": "a375473e19be608c5ec8325285ca6d84377ccb49",
         "type": "github"
       },
       "original": {
@@ -323,11 +323,11 @@
       },
       "locked": {
         "dir": "versions/weekly",
-        "lastModified": 1731093440,
-        "narHash": "sha256-+k2JYY9hCBcKHWxj3iq7duAtzXL2KTC73YA8O9fhObU=",
+        "lastModified": 1744721899,
+        "narHash": "sha256-QYJ32l5cw8sxuEXMSPPv4iXe8zwDWidSeyuvAtH/jvE=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "37cd2b92addb41382c4c6b3680e39d264d039b63",
+        "rev": "53a2122b07427d835aabc9d0cf070694afaff030",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### Summary
Remove ios bundling functions that were deprecated in 0.5 and removed in 0.6 (https://github.com/holochain/holochain/pull/4881)

### TODO:
- [x] CHANGELOG updated