### PR TITLE
ci: bump holochain/actions to v1.8.0

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   call:
-    uses: holochain/actions/.github/workflows/prepare-release.yml@v1.7.0
+    uses: holochain/actions/.github/workflows/prepare-release.yml@v1.8.0
     with:
       cliff_config: "https://raw.githubusercontent.com/holochain/release-integration/refs/heads/main/pre-1.0-cliff.toml"
       force_version: ${{ inputs.force_version }}


### PR DESCRIPTION
## Summary

Picks up [holochain/actions#9](https://github.com/holochain/actions/pull/9), which fixes the broken \`if: \${{ inputs.skip_semver_checks == 'false' }}\` conditional on the \`Install cargo-semver-checks\` step. On v1.7.0 that conditional was always evaluating false (boolean compared to a string in GitHub Actions expression syntax — booleans coerce to numbers, the string \`'false'\` parses to \`NaN\`, both \`0 == NaN\` and \`1 == NaN\` are false), so the install step was always skipped and the prepare step then died with \`no such command: 'semver-checks'\`. v1.8.0 evaluates the boolean directly with \`!inputs.skip_semver_checks\`.

The \`setup_script\` hook from [#8](https://github.com/holochain/actions/pull/8) (which downloads LLVM for the \`wasmer-sys-llvm\` semver check) is unchanged and still wired up in this workflow file.

## Test plan

- [x] One-line tag bump, YAML still valid
- [ ] Re-trigger the **Prepare a release** workflow manually after merge and confirm it gets past both the install step and the LLVM build, and that \`cargo-semver-checks\` actually runs against the full feature matrix