### PR TITLE
ci: install LLVM into RUNNER_TEMP, not the workspace

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -30,8 +30,16 @@ jobs:
       # to download the same prebuilt LLVM bundle the Windows test job
       # uses (see test.yml) and export the prefix env var so subsequent
       # steps — including the prepare step — can find it.
+      #
+      # The LLVM bundle MUST be installed outside `$GITHUB_WORKSPACE` so it
+      # doesn't end up staged into the auto-generated release commit by the
+      # downstream `peter-evans/create-pull-request` step. `$RUNNER_TEMP` is
+      # the canonical place: persistent across steps within the job, but
+      # outside the workspace and so invisible to git operations against the
+      # repo. Putting it under the workspace previously got the push
+      # rejected by GitHub's 100 MB file size limit on `clang-21`.
       setup_script: |
-        LLVM_DIR="$PWD/.llvm"
+        LLVM_DIR="$RUNNER_TEMP/llvm"
         mkdir -p "$LLVM_DIR"
         curl --proto '=https' --tlsv1.2 -sSf \
           "https://github.com/wasmerio/llvm-custom-builds/releases/download/21.x/llvm-linux-amd64.tar.xz" \


### PR DESCRIPTION
## Summary

The previous \`setup_script\` (added in #185) downloaded the LLVM bundle into \`\$PWD/.llvm\`, which is inside \`\$GITHUB_WORKSPACE\`. On the most recent prepare run that bit us:

1. ✅ \`Install cargo-semver-checks\` ran (the v1.8.0 fix from holochain/actions#9 worked)
2. ✅ \`Prepare release\` ran, semver-checks built the host crate with all features and passed
3. ❌ \`Create a release pull request\` (peter-evans/create-pull-request) tried to push the auto-generated release branch and got rejected by GitHub's pre-receive hook:

   \`\`\`
   remote: error: File .llvm/bin/clang-21 is 143.01 MB; this exceeds GitHub's file size limit of 100.00 MB
   remote: error: File .llvm/bin/clang-repl is 145.20 MB; this exceeds...
   remote: error: File .llvm/lib/libclang-cpp.so.21.1 is 115.19 MB; this exceeds...
   \`\`\`

The downstream commit step vacuums up everything in the workspace, including the unpacked LLVM toolchain. Several files in the bundle are over the 100 MB hard limit, so the push gets rejected and the whole release prep fails on the very last step.

See [the failing run](https://github.com/holochain/holochain-wasmer/actions/runs/24162537921/job/70516992473).

## Fix

One-line fix on our side: install LLVM into \`\$RUNNER_TEMP/llvm\` instead of \`\$PWD/.llvm\`. \`\$RUNNER_TEMP\` is the canonical "persistent within the job, outside the workspace" location for files like this on a GitHub-hosted runner. The path stays reachable across steps via \`LLVM_SYS_211_PREFIX\`, but the bundle is invisible to git operations against the repo, so create-pull-request no longer accidentally commits it.

The in-file comment is expanded to document why the location matters, so the next person doesn't move it back under the workspace and rediscover this failure mode.

## Test plan

- [x] YAML still validates
- [ ] Re-trigger the **Prepare a release** workflow manually after merge and confirm:
  - the LLVM download still works
  - \`cargo-semver-checks\` still runs and (one hopes) reports real findings on the deliberate breaking changes for this release
  - the auto-generated release PR push succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow configuration to optimize the build environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->